### PR TITLE
Moff hair

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/human_hair.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/human_hair.yml
@@ -1,3 +1,22 @@
+# SPDX-FileCopyrightText: 2022 Flipp Syder <76629141+vulppine@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Bloody2372 <146976013+Bloody2372@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 KingFroozy <140668342+KingFroozy@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 MACMAN2003 <macman2003c@gmail.com>
+# SPDX-FileCopyrightText: 2023 liltenhead <104418166+liltenhead@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Илья Стокалюк <darkelement237@mail.ru>
+# SPDX-FileCopyrightText: 2024 Emisse <99158783+Emisse@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Futuristic-OK <141568243+Futuristic-OK@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 RenQ <164364533+ImRenQ@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Ubaser <134914314+UbaserB@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 UnicornOnLSD <149102472+UnicornOnLSD@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 nao fujiwara <awkwarddryad@gmail.com>
+# SPDX-FileCopyrightText: 2024 ~DreamlyJack~ <148849095+DreamlyJack@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Арт <123451459+JustArt1m@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+# SPDX-FileCopyrightText: 2025 OnyxTheBrave <vinjeerik@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
 - type: marking
   id: HumanHairAfro
   bodyPart: Hair


### PR DESCRIPTION
<!-- New to Sector Vestige? Please read our CONTRIBUTING guide:
https://github.com/Sector-Vestige/Sector-Vestige/blob/master/CONTRIBUTING.md -->

## About the PR
Hair for moffs

## Why / Balance
Serendipidy baldwing is a tragedy

## Technical Details
I added the species restriction of every species that has the default human hair + moths to all of the human hairs. I debated just removing the species restriction tag from the MobMothMarkingsLimits but I felt like that could cause more issues later down the road.

## Media (if applicable)
<!--
Include screenshots or videos if this PR adds or changes anything visual.
If this PR is purely code, small fixes, or backend-only, you can omit this.
-->

## Requirements
<!-- Confirm the following by placing an X inside each [ ] -->
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR, or it does not require an in-game showcase.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige


<!-- PRs that do not follow these requirements may be delayed or closed. -->

## Breaking Changes
None

## Changelog

:cl:
- add: Moths have hair now.

