### PR TITLE
Encryption Keys in Headphones

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Multiple/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/misc.yml
@@ -1,3 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Wizards Den contributors
+# SPDX-FileCopyrightText: 2025 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+# SPDX-FileCopyrightText: 2025 qu4drivium <aaronholiver@outlook.com>
+#
+# SPDX-License-Identifier: MIT
+
 - type: entity
   parent: Clothing
   id: ClothingMultipleHeadphones


### PR DESCRIPTION
## About the PR
You can fit encryption keys inside of headphones now!

## Why / Balance
Considering they can be worn in the ear headset slot... it'd be funny. 

## Media
<img width="435" height="269" alt="Screenshot 2025-10-18 083625" src="https://github.com/user-attachments/assets/fe2a46f8-6f7c-4a38-b0be-c685b7f75a0e" />
<img width="1571" height="410" alt="Screenshot 2025-10-18 083759" src="https://github.com/user-attachments/assets/399d96fc-0954-4a82-be3b-3336ce731939" />

## Technical Details
Six line yaml change my beloved.

## Breaking Changes
None!

## Requirements
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

## Changelog
:cl:
- tweak: Encryption keys can now fit inside headphones.