### PR TITLE
Network Linking the Requisition Digiboard

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/folders.yml
@@ -1,3 +1,12 @@
+# SPDX-FileCopyrightText: 2025 Wizards Den contributors
+# SPDX-FileCopyrightText: 2025 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+# SPDX-FileCopyrightText: 2025 Winkarst <74284083+Winkarst-cpu@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 qu4drivium <aaronholiver@outlook.com>
+#
+# SPDX-License-Identifier: MIT
+
 - type: entity
   parent: BaseItem
   id: BoxFolderNuclearCodes


### PR DESCRIPTION
## About the PR
It allows you to link the digiboard to a Cargo Telepad.

## Why / Balance
This gives the digiboard a bit more longevity, seeing as telepads are researched every shift.

## Media
<img width="1531" height="340" alt="Screenshot 2025-10-18 092514" src="https://github.com/user-attachments/assets/3e022b83-fc3b-43d5-8a5c-5e0a288b12ad" />
<img width="286" height="253" alt="Screenshot 2025-10-18 092557" src="https://github.com/user-attachments/assets/8e88a3bd-e93e-4b45-bbef-261dc4b3497f" />

## Technical Details
Yaml changes my beloved.

## Breaking Changes
None!

## Requirements
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

## Changelog
:cl:
- tweak: The digiboard can now be linked to cargo telepads.