### PR TITLE
FoxFolk Can Eat Mice (Rejoice)

### DIFF
--- a/Resources/Prototypes/_CD/Body/Prototypes/foxfolk.yml
+++ b/Resources/Prototypes/_CD/Body/Prototypes/foxfolk.yml
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2025 Cosmatic Drift contributors
+# SPDX-FileCopyrightText: 2025 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2022 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Jezithyr <Jezithyr@gmail.com>
+# SPDX-FileCopyrightText: 2023 Flareguy <78941145+Flareguy@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+# SPDX-FileCopyrightText: 2025 qu4drivium <aaronholiver@outlook.com>
+#
+# SPDX-License-Identifier: MIT
+
 - type: body
   id: Foxfolk
   name: foxfolk


### PR DESCRIPTION
## About the PR
This PR gives Foxfolk the OrganAnimalStomach instead of the human one, allowing them to safely eat mice, raw meat, etc. 

## Why / Balance
Vulpkanins have animal stomachs, so it only makes sense that Foxfolk do as well. Additionally, Foxfolk couldn't eat mice, and that was very tragic.

## Technical Details
One line yaml change.

## Breaking Changes
None!

## Requirements
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

## Changelog
:cl:
- tweak: Foxfolk now have Animal stomachs.