### PR TITLE
Fixing the ready button.

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -164,7 +164,7 @@ namespace Content.Client.Lobby
 
         private void OnReadyToggled(BaseButton.ButtonToggledEventArgs args)
         {
-            // Sector Vestige - Prevent recursive updates from programmatic state changes
+            // Sector Vestige - Begin - Prevent recursive updates from programmatic state changes
             if (_updatingReadyButton)
                 return;
 
@@ -248,12 +248,12 @@ namespace Content.Client.Lobby
             else
             {
                 Lobby!.StartTime.Text = string.Empty;
-                // Sector Vestige - Fix ready button text and state order
+                // Sector Vestige - Begin - Fix ready button text and state order
                 Lobby!.ReadyButton.Text = Loc.GetString(_gameTicker.AreWeReady ? "lobby-state-player-status-ready" : "lobby-state-player-status-not-ready");
                 Lobby!.ReadyButton.ToggleMode = true;
                 Lobby!.ReadyButton.Disabled = false;
                 Lobby!.ManifestButton.Disabled = false; // Moffstation - Ready manifest
-                // Set flag to prevent OnReadyToggled from firing when we set Pressed programmatically
+                // Sector Vestige - Set flag to prevent OnReadyToggled from firing when we set Pressed programmatically
                 _updatingReadyButton = true;
                 Lobby!.ReadyButton.Pressed = _gameTicker.AreWeReady;
                 _updatingReadyButton = false;


### PR DESCRIPTION
<!-- New to Sector Vestige? Please read our CONTRIBUTING guide:
https://github.com/Sector-Vestige/Sector-Vestige/blob/master/CONTRIBUTING.md -->

## About the PR
Fixes the lobby ready button displaying inverted text ("Not Ready" when ready, "Ready" when not ready) and resolving state after clicking due to incorrect event handling order.

## Why / Balance
This fixes a bug introduced in commit c725c5017e where the ready button's text and state became desynchronized. The issue occurred because:
1. The button text was being set based on the button's current pressed state before that state was updated from the server
2. Setting the button's `Pressed` property programmatically was triggering the toggle event handler, which sent an unwanted toggle command back to the server, inverting the ready state

This was causing user confusion as clicking "Ready" would show "Not Ready" and vice versa, plus it would sometimes revoke the ready state unexpectedly.

## Media
<!--
Include screenshots or videos if this PR adds or changes anything visual.
If this PR is purely backend code or doesn't require visual demonstration, you can leave this section empty.
-->`
<img width="720" height="263" alt="image" src="https://github.com/user-attachments/assets/d5bf9a47-1a9f-427e-8d7b-17a24122308d" />


## Technical Details
**Changes made:**
1. Added a `_updatingReadyButton` flag to prevent recursive event handling when the button state is updated programmatically from the server
2. Modified `OnReadyToggled` to check the flag and return early during programmatic updates, preventing unwanted `toggleready` commands
3. Added immediate text update in `OnReadyToggled` so the button text changes instantly when clicked by the user
4. In `UpdateLobbyUi()`, the button text is now set using `_gameTicker.AreWeReady` directly before updating the `Pressed` state, and the `Pressed` update is wrapped with the flag to prevent event recursion

This ensures the button text and visual state always match the actual ready state, and user interactions don't cause unintended state inversions.

## Breaking Changes
None

*Note: Rebound was too lazy so this PR description was AI generated*

## Requirements
<!-- Confirm the following by placing an X inside each [ ] -->
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

<!-- PRs that do not meet these requirements may be delayed or closed. -->

## Changelog
<!--
List player-facing changes below using this exact format.
Only entries after the ':cl:' tag will be picked up by Weh Bot.

Valid types: add, remove, tweak, fix
Use lowercase only (e.g., 'add', not 'Add').

Example:
:cl:
- add: Added new medical scanner UI.
- fix: Fixed lockers not opening.
-->

:cl:
- fix: Fixed Riv's oopsie (the Ready button works again)
