### PR TITLE
Air Alarm Threshold Harpy Fix

### DIFF
--- a/Resources/Prototypes/Atmospherics/Thresholds/airalarms.yml
+++ b/Resources/Prototypes/Atmospherics/Thresholds/airalarms.yml
@@ -36,7 +36,7 @@
   lowerBound: !type:AlarmThresholdSetting
     threshold: 0.10
   upperBound: !type:AlarmThresholdSetting
-    threshold: 0.3
+    threshold: 1.0 #SV change for harpy air mixes
   lowerWarnAround: !type:AlarmThresholdSetting
     threshold: 1.5
   upperWarnAround: !type:AlarmThresholdSetting


### PR DESCRIPTION
Changed the threshold for oxygen on air alarms to no longer broadcast warnings/danger when the air mix has sufficient oxygen for harpies.

## About the PR
Changes the default upper threshold for oxygen on air alarms from 0.3 -> 1.0

## Why / Balance
Air alarms currently broadcast warnings/danger when oxygenation is sufficient for harpies, which can cause confusion/issues with fire locks because atmospherics did their job properly

## Media

<img width="809" height="527" alt="Screenshot (1181)" src="https://github.com/user-attachments/assets/c052e1ef-8948-464b-93f2-99526529dca3" />
Look at this air alarm. It's thresholds are cool and harpypilled.

## Breaking Changes
None

## Requirements
<!-- Confirm the following by placing an X inside each [ ] -->
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

<!-- PRs that do not meet these requirements may be delayed or closed. -->

## Changelog
:cl:
- Changed air alarm thresholds for harpies
