### PR TITLE
Air Alarm Threshold Harpy Fix

### DIFF
--- a/Resources/Prototypes/Atmospherics/Thresholds/airalarms.yml
+++ b/Resources/Prototypes/Atmospherics/Thresholds/airalarms.yml
@@ -1,3 +1,22 @@
+# SPDX-FileCopyrightText: 2025 Wizards Den contributors
+# SPDX-FileCopyrightText: 2025 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2022 Eoin Mcloughlin <helloworld@eoinrul.es>
+# SPDX-FileCopyrightText: 2022 Flipp Syder <76629141+vulppine@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 corentt <36075110+corentt@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 eoineoineoin <eoin.mcloughlin+gh@gmail.com>
+# SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
+# SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Partmedia <kevinz5000@gmail.com>
+# SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+# SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
+# SPDX-FileCopyrightText: 2025 ArtisticRoomba <145879011+ArtisticRoomba@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Errant <35878406+Errant-4@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+# SPDX-FileCopyrightText: 2025 EvilAtheist <88866615+Mixmaster49@users.noreply.github.com>
+#
+# SPDX-License-Identifier: MIT
+
 # Threshold prototypes for AtmosMonitors
 
 # NOTE: Warning thresholds are given as multipliers of the danger bound. For


### PR DESCRIPTION
Changed the threshold for oxygen on air alarms to no longer broadcast warnings/danger when the air mix has sufficient oxygen for harpies.

## About the PR
Changes the default upper threshold for oxygen on air alarms from 0.3 -> 1.0

## Why / Balance
Air alarms currently broadcast warnings/danger when oxygenation is sufficient for harpies, which can cause confusion/issues with fire locks because atmospherics did their job properly.

## Media
<img width="809" height="527" alt="Screenshot (1181)" src="https://github.com/user-attachments/assets/331176e1-e10b-40eb-9292-133cb9098a61" />
Look at this air alarm. It's thresholds are cool and harpypilled. 

## Breaking Changes
None

## Requirements
<!-- Confirm the following by placing an X inside each [ ] -->
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

<!-- PRs that do not meet these requirements may be delayed or closed. -->

## Changelog

:cl:
- Changed air alarm thresholds for harpies