### PR TITLE
Catatonic and Soulless Inspect Text Tweak

### DIFF
--- a/Resources/Locale/en-US/mind/components/mind-component.ftl
+++ b/Resources/Locale/en-US/mind/components/mind-component.ftl
@@ -4,8 +4,8 @@ comp-mind-ghosting-prevented = You are not able to ghost right now.
 
 ## Messages displayed when a body is examined and in a certain state
 
-comp-mind-examined-catatonic = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } totally catatonic. The stresses of life in deep-space must have been too much for { OBJECT($ent) }. Any recovery is impossible.
+comp-mind-examined-catatonic = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } totally catatonic. { CAPITALIZE(SUBJECT($ent)) } may need many days to recover.
 comp-mind-examined-dead = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } dead.
 comp-mind-examined-ssd = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-HAVE($ent) } a blank, absent-minded stare and appears completely unresponsive to anything. { CAPITALIZE(SUBJECT($ent)) } may snap out of it soon.
 comp-mind-examined-dead-and-ssd = { CAPITALIZE(POSS-ADJ($ent)) } soul lies dormant and may return soon.
-comp-mind-examined-dead-and-irrecoverable = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed and moved on. Any recovery is impossible.
+comp-mind-examined-dead-and-irrecoverable = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed and moved on. { CAPITALIZE(SUBJECT($ent)) } may need many days to recover if revived.


### PR DESCRIPTION
## About the PR
Tweaks the inspect text of catatonic and soulless people for more roleplay consistency.

## Why / Balance
Flavor text, roleplay reasons.

## Media
<img width="530" height="237" alt="Screenshot 2026-01-21 090951" src="https://github.com/user-attachments/assets/57961207-291d-4c5f-a0cb-5f4246597fe5" />
<img width="568" height="248" alt="Screenshot 2026-01-21 091006" src="https://github.com/user-attachments/assets/14650c0c-5fe0-4c59-b56c-b419fe94b237" />

## Technical Details
One sentence change. The world is beautiful.

## Breaking Changes
None.

## Requirements
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

## Changelog
- tweak: Slightly edited the inspect text for catatonic and soulless people.