### PR TITLE
Fixes Synths Having No Blood

### DIFF
--- a/Content.Server/_CD/Traits/SynthComponent.cs
+++ b/Content.Server/_CD/Traits/SynthComponent.cs
@@ -1,6 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Sector-Vestige contributors
 // SPDX-FileCopyrightText: 2025 Contributors of the _CD upstream project
 // SPDX-FileCopyrightText: 2025 OnyxTheBrave <vinjeerik@gmail.com>
+// SPDX-FileCopyrightText: 2025 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+// SPDX-FileCopyrightText: 2026 qu4drivium <aaronholiver@outlook.com>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Content.Server/_CD/Traits/SynthSystem.cs
+++ b/Content.Server/_CD/Traits/SynthSystem.cs
@@ -1,6 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Sector-Vestige contributors
 // SPDX-FileCopyrightText: 2025 Contributors of the _CD upstream project
 // SPDX-FileCopyrightText: 2025 OnyxTheBrave <vinjeerik@gmail.com>
+// SPDX-FileCopyrightText: 2025 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+// SPDX-FileCopyrightText: 2026 qu4drivium <aaronholiver@outlook.com>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/_CD/Traits/traits.yml
+++ b/Resources/Prototypes/_CD/Traits/traits.yml
@@ -1,6 +1,8 @@
+# SPDX-FileCopyrightText: 2026 Sector-Vestige contributors
 # SPDX-FileCopyrightText: 2025 Contributors of the _CD upstream project
 # SPDX-FileCopyrightText: 2025 OnyxTheBrave <vinjeerik@gmail.com>
 # SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+# SPDX-FileCopyrightText: 2026 qu4drivium <aaronholiver@outlook.com>
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
## About the PR
Fixes an issue with Synthetics that made them slooooowly bleed all their bloodstream until they had only one unit of blood in their bodies.

## Why / Balance
Synthetics had turbo anemia and would take max bloodloss after receiving papercuts, which is not ideal.

## Media
<img width="981" height="710" alt="image" src="https://github.com/user-attachments/assets/6fbd91d3-ece8-44c5-8680-78617c5dcdd6" />
<img width="824" height="630" alt="image" src="https://github.com/user-attachments/assets/a8f8e598-70c2-45a1-9237-440ce7ec4b70" />
<img width="792" height="486" alt="image" src="https://github.com/user-attachments/assets/9906bfc9-1441-4748-a8ec-aa7d3bc28cb2" />

## Technical Details
Replaced an obsolete method that was improperly giving synthetics their bloodstream.

## Breaking Changes
None.

## Requirements
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

## Changelog
- fix: Fixed Synthetics having turbo anemia.