### PR TITLE
CC finally moves us out of a high density asteroid field

### DIFF
--- a/Resources/Prototypes/_SV/game_presets.yml
+++ b/Resources/Prototypes/_SV/game_presets.yml
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: 2026 Sector-Vestige contributors
 # SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
 # SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+# SPDX-FileCopyrightText: 2026 Mixmaster49 (GitHub)
 # SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 EvilAtheist <maximschaper49@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
## About the PR
Removes the meteor scheduler gamerule from the vestige extended ruleset.


## Why / Balance
Every single engineering player hates meteors. They take up engineering's time which could be spent RPing or doing interesting projects. Lowering the rate of meteors did not work, so removing them from the scheduler allows control of meteors (and engineering's sanity) to be up to the GMs and not random chance.

## Breaking Changes
None

## Requirements
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).
- 
## Changelog


:cl:
- remove: Removed the asteroid event from the Vestige Extended scheduler
