### PR TITLE
Straitjackets

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -166,8 +166,10 @@
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 whythelettuce <stephanietokai@gmail.com>
 # SPDX-FileCopyrightText: 2025 āda <ss.adasts@gmail.com>
-# SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Nico <74880554+NicoSGF64@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 qu4drivium <aaronholiver@outlook.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/_SV/Recipies/Lathes/lathepacks.yml
+++ b/Resources/Prototypes/_SV/Recipies/Lathes/lathepacks.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2026 Sector-Vestige contributors
+# SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2026 qu4drivium <aaronholiver@outlook.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: latheRecipePack
   id: SVMedfabStatic
   recipes:

--- a/Resources/Prototypes/_SV/Recipies/Lathes/medical.yml
+++ b/Resources/Prototypes/_SV/Recipies/Lathes/medical.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2026 Sector-Vestige contributors
+# SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2026 qu4drivium <aaronholiver@outlook.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: latheRecipe
   id: Straitjacket
   result: ClothingOuterStraightjacket


### PR DESCRIPTION
## About the PR
Allows straitjackets to be printed at the Medical Fabricator for 5 Cloth and 2.5 Plastic. As a treat.

## Why / Balance
Resolves #176. Also, there was no way to get straitjackets in-round without admin intervention before.

## Media
<img width="597" height="151" alt="Screenshot 2026-02-23 223957" src="https://github.com/user-attachments/assets/c24c45cb-98f0-4318-995a-980c99ca4bfc" />
<img width="279" height="153" alt="Screenshot 2026-02-23 224016" src="https://github.com/user-attachments/assets/b24ccfda-7d83-44a6-b275-88c26902373f" />

## Technical Details
Mostly yaml changes. Added a new directory to the _SV namespace for printing lathe stuff.

## Breaking Changes
None.

## Requirements
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

## Changelog
:cl:
- tweak: Straitjackets can now be printed at the Medical Fabricator.