### PR TITLE
Atmospherics - Update Default O2 Concentration

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -1,3 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Wizards Den contributors
+// SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+// SPDX-FileCopyrightText: 2020 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2020 Metal Gear Sloth <metalgearsloth@gmail.com>
+// SPDX-FileCopyrightText: 2020 Víctor Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2020 Víctor Aguilera Puerto <zddm@outlook.es>
+// SPDX-FileCopyrightText: 2020 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2021 20kdc <asdd2808@gmail.com>
+// SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto <gradientvera@outlook.com>
+// SPDX-FileCopyrightText: 2021 Visne <39844191+Visne@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2021 py01 <60152240+collinlunn@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 Rane <60792108+Elijahrane@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
+// SPDX-FileCopyrightText: 2022 wrexbe <81056464+wrexbe@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 Errant <35878406+dmnct@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
+// SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
+// SPDX-FileCopyrightText: 2023 Tom Leys <tom@crump-leys.com>
+// SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
+// SPDX-FileCopyrightText: 2023 username <113782077+whateverusername0@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 whateverusername0 <whateveremail>
+// SPDX-FileCopyrightText: 2024 Ilya246 <57039557+Ilya246@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+// SPDX-FileCopyrightText: 2024 Spanky <scott@wearejacob.com>
+// SPDX-FileCopyrightText: 2024 chromiumboy <50505512+chromiumboy@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 router <messagebus@vk.com>
+// SPDX-FileCopyrightText: 2025 ArtisticRoomba <145879011+ArtisticRoomba@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 K-Dynamic <20566341+K-Dynamic@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+// SPDX-FileCopyrightText: 2026 OnyxTheBrave <131422822+OnyxTheBrave@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 lambdatiger <spam.stnuocca.sl@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
 using Robust.Shared.Serialization;
 // ReSharper disable InconsistentNaming
 


### PR DESCRIPTION
<!-- New to Sector Vestige? Please read our CONTRIBUTING guide:
https://github.com/Sector-Vestige/Sector-Vestige/blob/master/CONTRIBUTING.md -->

## About the PR
<!--
What does this PR do?
Briefly summarize the changes, features, or fixes introduced.
-->
This PR increases the default O2 concentration.
## Why / Balance
<!--
Why was this change made?
- Does it fix a bug or issue? Link to the issue if applicable.
- Does it add a new feature? Explain the motivation.
- Does it affect game balance, gameplay design, or user experience? Explain how.
- Performance improvements? Describe the impact.
-->
Nanotrasen has the time to mine more oxygen so harpies aren't gasping on station.
## Media
<!--
Include screenshots or videos if this PR adds or changes anything visual.
If this PR is purely backend code or doesn't require visual demonstration, you can leave this section empty.
-->

## Technical Details
<!--
Explain any significant code-level details or logic.
Mention refactors, edge cases, or anything maintainers should be aware of.
If this is a simple change, you can keep this brief or omit it.
-->
Change two defines in `Atmospherics.cs` to increase default O2 to 25%. Affects the `fixgridatmos` command. Current stations and shuttles will have the old concentration unless they are updated by running the command again and saved.
## Breaking Changes
<!--
List any breaking changes to code structure or content.
This includes prototype name changes, class renames, or field changes that could affect downstream forks.
If there are none, write: "None"
-->
None
## Requirements
<!-- Confirm the following by placing an X inside each [ ] -->
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

<!-- PRs that do not meet these requirements may be delayed or closed. -->

## Changelog
<!--
List player-facing changes below using this exact format.
Only entries after the ':cl:' tag will be picked up by Weh Bot.

Valid types: add, remove, tweak, fix
Use lowercase only (e.g., 'add', not 'Add').

Example:
:cl:
- add: Added new medical scanner UI.
- fix: Fixed lockers not opening.
-->

:cl:
- tweak: Increased default O2 concentration.
