### PR TITLE
Cassettes Record For Longer

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: 2026 Delta-V contributors
 # SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
 # SPDX-FileCopyrightText: 2025 NakataRin <45946146+NakataRin@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+# SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 qu4drivium <aaronholiver@outlook.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
## About the PR
Increases the amount of time that one cassette from a Tape Recorder can record for. 3 Minutes -> 20 Minutes.

## Why / Balance
Because three minutes is just. Not nearly enough time for anything in HRP. You need like 10 cassettes to keep record of any long conversation, which sucks.

## Media
<img width="560" height="358" alt="image" src="https://github.com/user-attachments/assets/ecedcd60-25f6-4b0c-bfd7-8e1f0523353e" />

## Technical Details
One line yaml change my fucking BELOVED.

## Breaking Changes
None.

## Requirements
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

## Changelog
:cl:
- tweak: Cassettes now record for 20 minutes.