### PR TITLE
Senior Roles on Plasma

### DIFF
--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2025 Wizards Den contributors
-# SPDX-FileCopyrightText: 2025 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2026 Wizards Den contributors
+# SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
 # SPDX-FileCopyrightText: 2021 Timrod <timrod@gmail.com>
 # SPDX-FileCopyrightText: 2022 Cheackraze <71046427+Cheackraze@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
@@ -19,6 +19,7 @@
 # SPDX-FileCopyrightText: 2025 compilatron <40789662+Compilatron144@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 compilatron <40789662+jbox144@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 youtissoum <51883137+youtissoum@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 qu4drivium <aaronholiver@outlook.com>
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
## About the PR
Adds the Senior Roles to Plasma. Because they don't have them right now. 

## Why / Balance
fix :)

## Media
None needed.

## Technical Details
Yaml changes.

## Breaking Changes
None.

## Requirements
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

## Changelog
:cl:
- fix: Fixed Plasma lacking Senior roles.