### PR TITLE
Relocate Supermatter Guidebook Page

### DIFF
--- a/Resources/Prototypes/Guidebook/engineering.yml
+++ b/Resources/Prototypes/Guidebook/engineering.yml
@@ -1,4 +1,24 @@
-﻿- type: guideEntry
+# SPDX-FileCopyrightText: 2026 Wizards Den contributors
+# SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2023 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Aru Moon <anton17082003@gmail.com>
+# SPDX-FileCopyrightText: 2023 Julian Giebel <juliangiebel@live.de>
+# SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Naive817 <31364560+Naive817@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+# SPDX-FileCopyrightText: 2023 chromiumboy <50505512+chromiumboy@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 end <72604018+laok233@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Ben Velie <veliebm@gmail.com>
+# SPDX-FileCopyrightText: 2024 Dark <darkwindleaf@hotmail.co.uk>
+# SPDX-FileCopyrightText: 2025 ArtisticRoomba <145879011+ArtisticRoomba@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GrownSamoyedDog <61863648+GrownSamoyedDog@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 MDuch369 <109352266+MDuch369@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+# SPDX-FileCopyrightText: 2026 qu4drivium <aaronholiver@outlook.com>
+#
+# SPDX-License-Identifier: MIT
+
+- type: guideEntry
   id: Engineering
   name: guide-entry-engineering
   text: "/ServerInfo/Guidebook/Engineering/Engineering.xml"


### PR DESCRIPTION
## About the PR
Moves the Supermatter page in the Guidebook from the very top of everything to down in the Engineering subject under Power with the rest of the power sources.

## Why / Balance
For clarity and also for sorting. Looks pretty. Etc etc.
Resolves #174.

## Media
<img width="1082" height="297" alt="image" src="https://github.com/user-attachments/assets/2faf308b-6789-446b-a928-086f47a2de75" />

## Technical Details
One line yaml change.

## Breaking Changes
None.

## Requirements
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

## Changelog
:cl:
- tweak: Moved the Supermatter guidebook page to its proper place.