### PR TITLE
Security Cadets Get Personal Items

### DIFF
--- a/Resources/Prototypes/Loadouts/RoleLoadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/RoleLoadouts/role_loadouts.yml
@@ -25,10 +25,10 @@
 # SPDX-FileCopyrightText: 2025 jajsha <corbinbinouche7@gmail.com>
 # SPDX-FileCopyrightText: 2025 lzk <124214523+lzk228@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 qu4drivium <aaronholiver@outlook.com>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 OnyxTheBrave <131422822+OnyxTheBrave@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 qu4drivium <aaronholiver@outlook.com>
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
## About the PR
Adds personal items to Security Cadets.

## Why / Balance
fix :)
(every other intern role has them. i think we literally just forgot about cadets)

## Media
<img width="993" height="241" alt="image" src="https://github.com/user-attachments/assets/a4f1d9a3-ee87-400d-b097-c6bf225f704a" />

## Technical Details
One line yaml change.

## Breaking Changes
None.

## Requirements
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

## Changelog
:cl:
- fix: Cadets now have access to personal items.