### PR TITLE
More loadout fixes and additions

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -1,3 +1,38 @@
+# SPDX-FileCopyrightText: 2026 Wizards Den contributors
+# SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2021 Elijahrane <60792108+Elijahrane@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
+# SPDX-FileCopyrightText: 2022 Fishfish458 <47410468+Fishfish458@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Illiux <newoutlook@gmail.com>
+# SPDX-FileCopyrightText: 2022 Lamrr <96937466+Lamrr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Rane <60792108+Elijahrane@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 fishfish458 <fishfish458>
+# SPDX-FileCopyrightText: 2023 Alekshhh <44923899+Alekshhh@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 ChilbroBaggins <107660393+ChilbroBaggins@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Jeff <velcroboy333@hotmail.com>
+# SPDX-FileCopyrightText: 2023 JoeHammad1844 <130668733+JoeHammad1844@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 MagnusCrowe <whiterider1988@yahoo.com>
+# SPDX-FileCopyrightText: 2023 Maxtone <124747282+MagnusCrowe@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Puro <103608145+PuroSlavKing@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Whisper <121047731+QuietlyWhisper@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 lzk228 <124214523+lzk228@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Hanz <41141796+Hanzdegloker@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Moomoobeef <62638182+Moomoobeef@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Nim <128169402+Nimfar11@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 PoorMansDreams <150595537+PoorMansDreams@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Ubaser <134914314+UbaserB@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Minemoder5000 <minemoder50000@gmail.com>
+# SPDX-FileCopyrightText: 2025 Radezolid <snappednexus@gmail.com>
+# SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Sir Warock <67167466+SirWarock@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+# SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 āda <ss.adasts@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
+#
+# SPDX-License-Identifier: MIT
+
 # Medical supply lockers
 
 - type: entityTable

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -26,10 +26,10 @@
 # SPDX-FileCopyrightText: 2025 Radezolid <snappednexus@gmail.com>
 # SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Sir Warock <67167466+SirWarock@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
 # SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 āda <ss.adasts@gmail.com>
-# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -132,6 +132,7 @@
       - id: EmergencyRollerBedSpawnFolded
     - id: PlushieLizardJobParamedic
       prob: 0.02
+    - id: ETUGarmentBag # SV
 
 - type: entity
   parent: LockerParamedic

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -76,6 +76,7 @@
 # SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 āda <ss.adasts@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -246,6 +246,7 @@
   minLimit: 0
   loadouts:
   - HoPHead
+  - HoPBeretHarmony # Added by SV
 
 - type: loadoutGroup
   id: HoPJumpsuit
@@ -253,6 +254,12 @@
   loadouts:
   - HoPJumpsuit
   - HoPJumpskirt
+# Begin SV changes - Add Harmony's clothing to loadouts
+  - HoPJumpsuitTurtleneckHarmony
+  - HoPJumpskirtTurtleneckHarmony
+  - HoPJumpsuitMessKitHarmony
+  - HoPJumpskirtMessKitHarmony
+# End SV changes
 
 - type: loadoutGroup
   id: HoPNeck
@@ -920,7 +927,8 @@
   minLimit: 0
   loadouts:
   - ChiefEngineerHead
-  - ChiefEngineerBeret
+  - CEBeretHarmony # Added by SV
+  # - ChiefEngineerBeret # Removed by SV
 
 - type: loadoutGroup
   id: ChiefEngineerJumpsuit
@@ -1096,7 +1104,8 @@
   name: loadout-group-vestige-head #Changed by SV
   minLimit: 0
   loadouts:
-  - ResearchDirectorBeret
+  - RDBeretHarmony # Added by SV
+  # - ResearchDirectorBeret # Removed by SV
 
 - type: loadoutGroup
   id: ResearchDirectorNeck

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -72,11 +72,11 @@
 # SPDX-FileCopyrightText: 2025 youtissoum <51883137+youtissoum@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Afrokada <pchcraft@gmail.com>
 # SPDX-FileCopyrightText: 2026 JuneSzalkowska <juneszalkowska@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 OnyxTheBrave <131422822+OnyxTheBrave@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 āda <ss.adasts@gmail.com>
-# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/medical.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/medical.yml
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2026 Wizards Den contributors
 # SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
 # SPDX-FileCopyrightText: 2026 JuneSzalkowska <juneszalkowska@gmail.com>
-# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
 # SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 āda <ss.adasts@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/medical.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/medical.yml
@@ -239,6 +239,7 @@
   loadouts:
   - BlueShoes
   - WhiteShoes
+  - ShoesColorSlate # SV
   - MedicalWinterBoots
 
 #- type: loadoutGroup

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/medical.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/medical.yml
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2026 Wizards Den contributors
 # SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
 # SPDX-FileCopyrightText: 2026 JuneSzalkowska <juneszalkowska@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
 # SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 āda <ss.adasts@gmail.com>
-# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/Loadouts/RoleLoadouts/medical.yml
+++ b/Resources/Prototypes/Loadouts/RoleLoadouts/medical.yml
@@ -1,3 +1,12 @@
+# SPDX-FileCopyrightText: 2026 Wizards Den contributors
+# SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+# SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 āda <ss.adasts@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
+#
+# SPDX-License-Identifier: MIT
+
 ## Role Loadouts
 
 - type: roleLoadout

--- a/Resources/Prototypes/Loadouts/RoleLoadouts/medical.yml
+++ b/Resources/Prototypes/Loadouts/RoleLoadouts/medical.yml
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2026 Wizards Den contributors
 # SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
 # SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 āda <ss.adasts@gmail.com>
-# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/Loadouts/RoleLoadouts/medical.yml
+++ b/Resources/Prototypes/Loadouts/RoleLoadouts/medical.yml
@@ -9,6 +9,7 @@
   - ChiefMedicalOfficerJumpsuit
   - MedicalBackpack
   - ChiefMedicalOfficerOuterClothing
+  - MedicalGloves # SV
   - ChiefMedicalOfficerNeck
   - ChiefMedicalOfficerShoes
   - Glasses
@@ -27,6 +28,7 @@
   - MedicalDoctorJumpsuit
   - MedicalSpecializationBackpack # CD change from MedicalBackpack
   - MedicalDoctorOuterClothing
+  - MedicalGloves # SV
   - MedicalShoes
   - MedicalDoctorPDA
   - Glasses
@@ -57,6 +59,7 @@
   - ChemistJumpsuit
   - ChemistBackpack
   - ChemistOuterClothing
+  - MedicalGloves # SV
   - MedicalShoes
   - Glasses
   - SurvivalMedical
@@ -72,11 +75,12 @@
   - ParamedicHead
   # CD: ETU Gear
   - ParamedicMask
-  - MedicalMask
+  # - MedicalMask # SV
   - ParamedicJumpsuit
   # CD: ETU Gear
   - MedicalBackpack
   - ParamedicOuterClothing
+  - ParamedicGloves # SV
   - ParamedicShoes
   - Glasses
   - SurvivalMedical

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2025 Wizards Den contributors
-# SPDX-FileCopyrightText: 2025 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2026 Wizards Den contributors
+# SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
 # SPDX-FileCopyrightText: 2020 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2020 FL-OZ <58238103+FL-OZ@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2020 FL-OZ <anotherscuffed@gmail.com>
@@ -35,16 +35,19 @@
 # SPDX-FileCopyrightText: 2024 Brandon Hu <103440971+Brandon-Huu@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 BuildTools <unconfigured@null.spigotmc.org>
 # SPDX-FileCopyrightText: 2024 Ed <96445749+TheShuEd@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Errant <35878406+Errant-4@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Mr. 27 <45323883+Dutch-VanDerLinde@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Myra <vasilis@pikachu.systems>
 # SPDX-FileCopyrightText: 2024 Repo <47093363+Titian3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Errant <35878406+Errant-4@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 K-Dynamic <20566341+K-Dynamic@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Minemoder5000 <minemoder50000@gmail.com>
 # SPDX-FileCopyrightText: 2025 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
 # SPDX-FileCopyrightText: 2025 Spanky <scott@wearejacob.com>
+# SPDX-FileCopyrightText: 2025 beck-thompson <107373427+beck-thompson@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 qu4drivium <aaronholiver@outlook.com>
+# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -89,7 +89,7 @@
 - type: startingGear
   id: CaptainGear
   equipment:
-    shoes: ClothingShoesBootsLaceup
+    # shoes: ClothingShoesColorBrown # SV, removed due to loadout addition.
     eyes: ClothingEyesGlassesCommand
     gloves: ClothingHandsGlovesCaptain
     id: CaptainPDA

--- a/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Cosmatic Drift contributors
 # SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
-# SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+# SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Cosmatic Drift contributors
 # SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
 # SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
-# SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
@@ -82,6 +82,7 @@
   - SeniorPhysicianJumpsuit
   - MedicalBackpack
   - SeniorPhysicianOuterClothing
+  - MedicalGloves # SV
   - MedicalShoes
   - SurvivalMedical
   - Trinkets

--- a/Resources/Prototypes/_Harmony/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
 # SPDX-FileCopyrightText: 2024 DieselMohawk <gavin.drinka@gmail.com>
 # SPDX-FileCopyrightText: 2024 TheCrimsonJupiter <54331834+TheCrimsonJupiter@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BoskiYourk <175783845+BoskiYourk@users.noreply.guthub.com>
+# SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Harmony/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -12,21 +12,25 @@
   id: HoPJumpsuitTurtleneckHarmony
   equipment:
     jumpsuit: ClothingUniformJumpsuitHeadOfPersonnelTurtleneckHarmony
+  groupBy: "turtleneck" #SV
 
 - type: loadout
   id: HoPJumpskirtTurtleneckHarmony
   equipment:
     jumpsuit: ClothingUniformJumpskirtHeadOfPersonnelTurtleneckHarmony
+  groupBy: "turtleneck" #SV
     
 - type: loadout
   id: HoPJumpsuitMessKitHarmony
   equipment:
     jumpsuit: ClothingUniformJumpsuitHeadofPersonnelMessKitHarmony
+  groupBy: "messkit" #SV
 
 - type: loadout
   id: HoPJumpskirtMessKitHarmony
   equipment:
     jumpsuit: ClothingUniformJumpskirtHeadofPersonnelMessKitHarmony
+  groupBy: "messkit" #SV
 
 # Shoes
 - type: loadout

--- a/Resources/Prototypes/_Harmony/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -20,7 +20,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpskirtHeadOfPersonnelTurtleneckHarmony
   groupBy: "turtleneck" #SV
-    
+
 - type: loadout
   id: HoPJumpsuitMessKitHarmony
   equipment:

--- a/Resources/Prototypes/_SV/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/_SV/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -1,0 +1,5 @@
+# Gloves
+- type: loadout
+  id: NitrileGloves
+  equipment:
+    gloves: ClothingHandsGlovesNitrile

--- a/Resources/Prototypes/_SV/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/_SV/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2026 Sector-Vestige contributors
+# SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # Gloves
 - type: loadout
   id: NitrileGloves

--- a/Resources/Prototypes/_SV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_SV/Loadouts/loadout_groups.yml
@@ -96,7 +96,6 @@
 - type: loadoutGroup
   id: SeniorCourierShoes
   name: loadout-group-vestige-shoes
-  minLimit: 0
   loadouts:
   - BlackShoes
   - CargoWinterBoots
@@ -138,3 +137,18 @@
   minLimit: 0
   loadouts:
   - MagistrateBriefcase
+
+# Medical gloves
+- type: loadoutGroup
+  id: MedicalGloves
+  name: loadout-group-vestige-gloves
+  minLimit: 0
+  loadouts:
+  - LatexGloves
+  - NitrileGloves
+
+- type: loadoutGroup
+  id: ParamedicGloves
+  parent: MedicalGloves
+  loadouts:
+  - GlovesETUGauntlet # CD

--- a/Resources/Prototypes/_SV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_SV/Loadouts/loadout_groups.yml
@@ -10,7 +10,6 @@
 # SPDX-FileCopyrightText: 2026 JuneSzalkowska <juneszalkowska@gmail.com>
 # SPDX-FileCopyrightText: 2026 MissKay1994 <15877268+MissKay1994@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Nico <74880554+NicoSGF64@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 OnyxTheBrave <131422822+OnyxTheBrave@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 TakoDragon <69509841+BackeTako@users.noreply.github.com>
@@ -21,6 +20,7 @@
 # SPDX-FileCopyrightText: 2026 riv <234791249+qu4drivium@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 s3ptemb3rr (GitHub)
 # SPDX-FileCopyrightText: 2026 september <rdamico2204@gmail.com>
+# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_SV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_SV/Loadouts/loadout_groups.yml
@@ -10,6 +10,7 @@
 # SPDX-FileCopyrightText: 2026 JuneSzalkowska <juneszalkowska@gmail.com>
 # SPDX-FileCopyrightText: 2026 MissKay1994 <15877268+MissKay1994@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Nico <74880554+NicoSGF64@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 OnyxTheBrave <131422822+OnyxTheBrave@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 TakoDragon <69509841+BackeTako@users.noreply.github.com>
@@ -20,7 +21,6 @@
 # SPDX-FileCopyrightText: 2026 riv <234791249+qu4drivium@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 s3ptemb3rr (GitHub)
 # SPDX-FileCopyrightText: 2026 september <rdamico2204@gmail.com>
-# SPDX-FileCopyrightText: 2026 Nico64 <74880554+NicoSGF64@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
<!-- New to Sector Vestige? Please read our CONTRIBUTING guide:
https://github.com/Sector-Vestige/Sector-Vestige/blob/master/CONTRIBUTING.md -->

## About the PR
<!--
What does this PR do?
Briefly summarize the changes, features, or fixes introduced.
-->
Fixes https://github.com/Sector-Vestige/Sector-Vestige/issues/230, fixes https://github.com/Sector-Vestige/Sector-Vestige/issues/243, as well as two other loadout bugs relating to senior courier being able to spawn in shoeless and captain being forced to wear laceup shoes. Additionally, replaces the RD's and CE's with Harmony's versions, adds in the HoP's, and adds CD's ETU's can to the filled paramedic locker in case it's needed (mostly since the ETU clothing harness is inaccessible otherwise). _Doesn't_ add Harmony's beret to senior courier unless somehow June is okay with the sprite.

## Why / Balance
<!--
Why was this change made?
- Does it fix a bug or issue? Link to the issue if applicable.
- Does it add a new feature? Explain the motivation.
- Does it affect game balance, gameplay design, or user experience? Explain how.
- Performance improvements? Describe the impact.
-->
Bugfixes, plus drip being nice.


## Media
<!--
Include screenshots or videos if this PR adds or changes anything visual.
If this PR is purely backend code or doesn't require visual demonstration, you can leave this section empty.
-->
<img width="795" height="314" alt="CE head loadout" src="https://github.com/user-attachments/assets/00cc0ab3-6288-47b9-bab8-f8478c4a7b10" />
<img width="797" height="347" alt="RD head loadout" src="https://github.com/user-attachments/assets/6562cc6a-53ff-483c-bfc8-fddd55b5355e" />
<img width="794" height="563" alt="HoP head loadout" src="https://github.com/user-attachments/assets/e775559c-6f20-47eb-9118-22cc7ce75729" />
<img width="799" height="314" alt="HoP body loadout" src="https://github.com/user-attachments/assets/ad3503f5-024f-4236-86ff-4767623682c5" />

_**Note:** for the sake of brevity on the media preview, only the loadout for chemists and paramedics is shown, even if others are affected._

<img width="796" height="315" alt="Chemist gloves" src="https://github.com/user-attachments/assets/5d9b02f9-92ac-49f4-95f7-7ee995847caf" />
<img width="795" height="346" alt="Paramedic gloves" src="https://github.com/user-attachments/assets/8aa3f2b1-e802-4e16-95b6-731fe137f401" />
<img width="794" height="420" alt="Paramedic shoes" src="https://github.com/user-attachments/assets/89d4217c-3a9e-462d-862b-63e625b305b9" />
<img width="449" height="601" alt="ETU locker" src="https://github.com/user-attachments/assets/83f960f1-b6e0-4c8e-b203-549ab00e5cc2" />

## Technical details
<!--
Explain any significant code-level details or logic.
Mention refactors, edge cases, or anything maintainers should be aware of.
If this is a simple change, you can keep this brief or omit it.
-->
By namespace:
### Wizden:
- `loadout_groups.yml` and `medical.yml` (in `Loadouts/LoadoutGroups`) gets a bunch of new prototypes for the loadouts added, mostly Harmony's.
- `medical.yml` (in `Catalog/Fills/Lockers`) get CD's can taped on top.
- `captain.yml` in `Roles/Jobs/Command` gets the same treatment as the fix as the HoP.
### Harmony
- `Loadouts/Jobs/Command/head_of_personnel.yml` gets some new groupings for sake of looking nice.
### Sector Vestige
- Doctors get a new loadout prototype for nitrile gloves since somehow that didn't exist before.
- `MedicalGloves` gets added as a loadout group, from which `ParamedicGloves` parents off from (this will probably lead to me being murdered).

## Breaking Changes
<!--
List any breaking changes to code structure or content.
This includes prototype name changes, class renames, or field changes that could affect downstream forks.
If there are none, write: "None"
-->
`Resources/Prototypes/_Harmony/Loadouts/Jobs/Command/head_of_personnel.yml` gets its whitespace on line 23 removed because Harmony left it for some reason and the tests will explode if I don't remove it.

## Requirements
<!-- Confirm the following by placing an X inside each [ ] -->
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

<!-- PRs that do not meet these requirements may be delayed or closed. -->

## Changelog
<!--
List player-facing changes below using this exact format.
Only entries after the ':cl:' tag will be picked up by Weh Bot.

Valid types: add, remove, tweak, fix
Use lowercase only (e.g., 'add', not 'Add').

Example:
:cl:
- add: Added new medical scanner UI.
- fix: Fixed lockers not opening.
-->

:cl:
- add: The HoP has a new beret as well as new uniforms.
- add: All medical roles except for psychologists and medical interns now can have gloves on their loadouts.
- fix: Senior courier can no longer start shoeless.
- fix: Paramedics now can access their corresponding clothing both from their loadout screen as well as opening the ETU can now included on their locker.
- fix: Captains won't be forced to wear leather shoes anymore nor will a pair appear on the floor magically.
- tweak: The CE, RD now have been assigned their corresponding berets instead of generic departmental ones.
