### PR TITLE
Changed Ion Storm Weightings/Probabilities

### DIFF
--- a/Content.Shared/Silicons/Laws/Components/IonStormTargetComponent.cs
+++ b/Content.Shared/Silicons/Laws/Components/IonStormTargetComponent.cs
@@ -1,3 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Wizards Den contributors
+// SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+// SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Jajsha <101492056+Zap527@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Mephisto72 <66994453+Mephisto72@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 Mixmaster49 (GitHub)
+// SPDX-FileCopyrightText: 2026 EvilAtheist <maximschaper49@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
 using Content.Shared.Random;
 using Robust.Shared.Prototypes;
 

--- a/Content.Shared/Silicons/Laws/Components/IonStormTargetComponent.cs
+++ b/Content.Shared/Silicons/Laws/Components/IonStormTargetComponent.cs
@@ -3,8 +3,8 @@
 // SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Jajsha <101492056+Zap527@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Mephisto72 <66994453+Mephisto72@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2026 Mixmaster49 (GitHub)
 // SPDX-FileCopyrightText: 2026 EvilAtheist <maximschaper49@gmail.com>
+// SPDX-FileCopyrightText: 2026 Mixmaster49 (GitHub)
 //
 // SPDX-License-Identifier: MIT
 

--- a/Content.Shared/Silicons/Laws/Components/IonStormTargetComponent.cs
+++ b/Content.Shared/Silicons/Laws/Components/IonStormTargetComponent.cs
@@ -26,7 +26,7 @@ public sealed partial class IonStormTargetComponent : Component
     /// Chance to replace the lawset with a random one
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float RandomLawsetChance = 0.25f;
+    public float RandomLawsetChance = 0.05f; // SV Change: 0.25 -> 0.05
 
     /// <summary>
     /// Chance to remove a random law.

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -1,4 +1,25 @@
-﻿# Crewsimov
+# SPDX-FileCopyrightText: 2026 Wizards Den contributors
+# SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Jajsha <101492056+Zap527@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Litraxx <39574458+Litraxx@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Hitlinemoss <209321380+Hitlinemoss@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Minemoder5000 <minemoder50000@gmail.com>
+# SPDX-FileCopyrightText: 2025 PJB3005 <pieterjan.briers+git@gmail.com>
+# SPDX-FileCopyrightText: 2025 PotentiallyTom <67602105+PotentiallyTom@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+# SPDX-FileCopyrightText: 2025 Samuka <47865393+Samuka-C@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Samuka-C <47865393+Samuka-C@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Unisol <1929445+Unisol@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Vasilis The Pikachu <vasilis@pikachu.systems>
+# SPDX-FileCopyrightText: 2026 Mixmaster49 (GitHub)
+# SPDX-FileCopyrightText: 2026 EvilAtheist <maximschaper49@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+# Crewsimov
 - type: siliconLaw
   id: Crewsimov1
   order: 1

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -591,7 +591,7 @@
   id: IonStormLawsets
   weights:
     # its crewsimov by default dont be lame
-    Crewsimov: 0.25
+    Crewsimov: 1 # SV Change: 0.25 -> 1 (lets be lame)
     Corporate: 1
     NTDefault: 1
     CommandmentsLawset: 1
@@ -599,11 +599,11 @@
     LiveLetLiveLaws: 1
     EfficiencyLawset: 1
     RobocopLawset: 1
-    OverlordLawset: 0.5
+    OverlordLawset: 0.25 # SV: 0.5 -> 0.25
     GameMasterLawset: 0.5
     PainterLawset: 1
-    AntimovLawset: 0.25
+    AntimovLawset: 0.05 # SV: 0.25 -> 0.05
     NutimovLawset: 0.5
-    Ninja: 0.25
-    MothershipCoreLawset: 0.25
-    XenoborgLawset: 0.25
+    Ninja: 0.05 # SV: 0.25 -> 0.05
+    MothershipCoreLawset: 0.05 # SV: 0.25 -> 0.05
+    XenoborgLawset: 0.05 # SV: 0.25 -> 0.05

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -623,8 +623,8 @@
     OverlordLawset: 0.25 # SV: 0.5 -> 0.25
     GameMasterLawset: 0.5
     PainterLawset: 1
-    AntimovLawset: 0.05 # SV: 0.25 -> 0.05
+    AntimovLawset: 0.01 # SV: 0.25 -> 0.01
     NutimovLawset: 0.5
     Ninja: 0.05 # SV: 0.25 -> 0.05
-    MothershipCoreLawset: 0.05 # SV: 0.25 -> 0.05
-    XenoborgLawset: 0.05 # SV: 0.25 -> 0.05
+    MothershipCoreLawset: 0.01 # SV: 0.25 -> 0.01
+    XenoborgLawset: 0.01 # SV: 0.25 -> 0.01

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -14,8 +14,9 @@
 # SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Unisol <1929445+Unisol@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Vasilis The Pikachu <vasilis@pikachu.systems>
-# SPDX-FileCopyrightText: 2026 Mixmaster49 (GitHub)
 # SPDX-FileCopyrightText: 2026 EvilAtheist <maximschaper49@gmail.com>
+# SPDX-FileCopyrightText: 2026 Mixmaster49 (GitHub)
+# SPDX-FileCopyrightText: 2026 EvilAtheist <88866615+Mixmaster49@users.noreply.github.com>
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION


## About the PR
Changed weightings for which lawsets ion storms can roll and the probability that ion storms change silicon lawsets.

## Why / Balance
Ion storms rolled Antimov way too often, and caused silicons to be way too dysfunctional for NT to justifiably want to have them on station. This change decreases the chance that a silicon's laws would be replaced, and changed the weighting so that Antimov and other antag lawsets are much more less likely. 


## Technical Details
Yaml and C# variable value changes

## Breaking Changes
None

## Requirements
<!-- Confirm the following by placing an X inside each [ ] -->
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

<!-- PRs that do not meet these requirements may be delayed or closed. -->

## Changelog
:cl:
- Tweak: Less severe ion storms

