### PR TITLE
Fix layering of two gauze markings

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/gauze.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/gauze.yml
@@ -105,7 +105,7 @@
 
 - type: marking
   id: GauzeLowerArmRight
-  bodyPart: Overlay
+  bodyPart: RHand
   groupWhitelist: [Human, Reptilian, Arachnid, Rodentia, Foxfolk] # CD: Rodentia, Foxfolks.
   coloring:
     default:
@@ -118,7 +118,7 @@
 
 - type: marking
   id: GauzeLeftArm
-  bodyPart: Overlay
+  bodyPart: LArm
   groupWhitelist: [Human, Reptilian, Arachnid, Rodentia, Foxfolk] # CD: Rodentia, Foxfolks.
   coloring:
     default:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/gauze.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/gauze.yml
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2026 Wizards Den contributors
+# SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+# SPDX-FileCopyrightText: 2024 KittenColony <149278380+KittenColony@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Арт <123451459+JustArt1m@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ReboundQ3 <ReboundQ3@gmail.com>
+# SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 pathetic meowmeow <uhhadd@gmail.com>
+# SPDX-FileCopyrightText: 2026 Alzore <blackern5000@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
 # Generic Markings
 - type: marking
   id: GauzeLefteyePatch


### PR DESCRIPTION
## About the PR
Fixes #302

## Why / Balance
Because gauze markings overlaying over clothes like that is rather ugly and doesn't make sense.

I'm unsure if this requires commenting or not, seeing as I'm changing what I presume was an unintentional difference from upstream (there was no comment) to match what upstream has.

## Media
BEFORE
<img width="239" height="251" alt="image" src="https://github.com/user-attachments/assets/5ee0608f-adaf-45ff-8c38-627c121abf40" />
AFTER
<img width="169" height="250" alt="image" src="https://github.com/user-attachments/assets/1bd7c849-f8b0-41d8-88e4-34b8c4a92755" />
(Seems hands still overlay over clothes, but this pr is just copying what it looks like upstream)

## Requirements
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

## Changelog
:cl:
- fix: Fixed certain gauze arm markings incorrectly using the "Overlay" layer