### PR TITLE
QOL: Ore dumping

### DIFF
--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Stacks;
+using Content.Shared.Storage.Components; // SV changes - Dump ore bags into material storage (issue #245)
 using Content.Shared.Whitelist;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
@@ -35,6 +36,10 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         SubscribeLocalEvent<MaterialStorageComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<MaterialStorageComponent, InteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<MaterialStorageComponent, TechnologyDatabaseModifiedEvent>(OnDatabaseModified);
+        // SV changes start - Dump ore bags into material storage (issue #245)
+        SubscribeLocalEvent<MaterialStorageComponent, GetDumpableVerbEvent>(OnGetDumpableVerb);
+        SubscribeLocalEvent<MaterialStorageComponent, DumpEvent>(OnDump);
+        // SV changes end
     }
 
     public override void Update(float frameTime)
@@ -404,6 +409,39 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
             return;
         args.Handled = TryInsertMaterialEntity(args.User, args.Used, uid, component);
     }
+
+    // SV changes start - Dump ore bags into material storage (issue #245)
+    /// <summary>
+    /// Advertises the machine as a valid dump target (e.g. emptying an ore bag onto it)
+    /// so the dumpable system will route the bag's contents through here.
+    /// </summary>
+    private void OnGetDumpableVerb(Entity<MaterialStorageComponent> ent, ref GetDumpableVerbEvent args)
+    {
+        if (!ent.Comp.InsertOnInteract)
+            return;
+        args.Verb = Loc.GetString("dump-material-storage-verb-name", ("unit", ent.Owner));
+    }
+
+    /// <summary>
+    /// Handles a storage container (such as an ore bag) being dumped onto the machine,
+    /// inserting every contained entity that qualifies as a material.
+    /// </summary>
+    private void OnDump(Entity<MaterialStorageComponent> ent, ref DumpEvent args)
+    {
+        if (args.Handled || !ent.Comp.InsertOnInteract)
+            return;
+
+        foreach (var entity in args.DumpQueue)
+        {
+            if (TryInsertMaterialEntity(args.User, entity, ent, ent.Comp))
+                args.PlaySound = true;
+        }
+
+        // Mark handled even if nothing fit, so the dumpable system doesn't fall back to
+        // scattering the bag's contents on the floor.
+        args.Handled = true;
+    }
+    // SV changes end
 
     private void OnDatabaseModified(Entity<MaterialStorageComponent> ent, ref TechnologyDatabaseModifiedEvent args)
     {

--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -1,3 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Wizards Den contributors
+// SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+// SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+// SPDX-FileCopyrightText: 2024 Plykiya <58439124+Plykiya@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Zylofan <80375291+Zylofan@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Winkarst <74284083+Winkarst-cpu@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+//
+// SPDX-License-Identifier: MIT
+
 using System.Linq;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;

--- a/Resources/Locale/en-US/storage/components/dumpable-component.ftl
+++ b/Resources/Locale/en-US/storage/components/dumpable-component.ftl
@@ -2,3 +2,4 @@ dump-verb-name = Dump out on ground
 dump-disposal-verb-name = Dump out into {$unit}
 dump-placeable-verb-name = Dump out onto {$surface}
 dump-smartfridge-verb-name = Restock into {$unit}
+dump-material-storage-verb-name = Empty into {$unit}


### PR DESCRIPTION
<!-- New to Sector Vestige? Please read our CONTRIBUTING guide:
https://github.com/Sector-Vestige/Sector-Vestige/blob/master/CONTRIBUTING.md -->

## About the PR
<!--
What does this PR do?
Briefly summarize the changes, features, or fixes introduced.
-->

This PR adds the ability for people to use orebags to just dump their ores into the ore-processor by left-clicking it with a orebag.

## Why / Balance
<!--
Why was this change made?
- Does it fix a bug or issue? Link to the issue if applicable.
- Does it add a new feature? Explain the motivation.
- Does it affect game balance, gameplay design, or user experience? Explain how.
- Performance improvements? Describe the impact.
-->

It was requested by september in #245 and was a small ish fix that could be implemented easily.
This PR therefore closes #245 

## Media
<!--
Include screenshots or videos if this PR adds or changes anything visual.
If this PR is purely backend code or doesn't require visual demonstration, you can leave this section empty.
-->

<img width="600" height="362" alt="image" src="https://github.com/user-attachments/assets/87ed6b56-9c11-49e8-9019-13c22d78f46c" />

## Technical Details
<!--
Explain any significant code-level details or logic.
Mention refactors, edge cases, or anything maintainers should be aware of.
If this is a simple change, you can keep this brief or omit it.
-->

Adds two new methods, onGetDumpableVerb and OnDump.

OnGetDumpable adds a verb to whenever the bag is dumpable and OnDump adds a method tot check if the contained entities qualify as materials so that we're not gonna dump in lasers or food.

## Breaking Changes
<!--
List any breaking changes to code structure or content.
This includes prototype name changes, class renames, or field changes that could affect downstream forks.
If there are none, write: "None"
-->

None

## Requirements
<!-- Confirm the following by placing an X inside each [ ] -->
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

<!-- PRs that do not meet these requirements may be delayed or closed. -->

## Changelog
<!--
List player-facing changes below using this exact format.
Only entries after the ':cl:' tag will be picked up by Weh Bot.

Valid types: add, remove, tweak, fix
Use lowercase only (e.g., 'add', not 'Add').

Example:
:cl:
- add: Added new medical scanner UI.
- fix: Fixed lockers not opening.
-->

:cl:
- add: You can now dump ores in to the ore processor with your ore-bag using left click.

