### PR TITLE
Door Remote - Add Alt-Interaction

### DIFF
--- a/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
+++ b/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
@@ -1,3 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Wizards Den contributors
+// SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+// SPDX-FileCopyrightText: 2024 Jake Huxell <JakeHuxell@pm.me>
+// SPDX-FileCopyrightText: 2024 Plykiya <58439124+Plykiya@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Fildrance <fildrance@gmail.com>
+// SPDX-FileCopyrightText: 2025 Samuka <47865393+Samuka-C@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 OnyxTheBrave <131422822+OnyxTheBrave@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 lunarcomets <140772713+lunarcomets@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 lambdatiger <spam.stnuocca.sl@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
 using Content.Shared.Access.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;

--- a/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
+++ b/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
@@ -10,9 +10,11 @@ using Content.Shared.Popups;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.Remotes.Components;
 using Content.Shared.Tag;
+using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Remotes.EntitySystems;
 
@@ -33,13 +35,45 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<DoorRemoteComponent, DoorRemoteModeChangeMessage>(OnDoorRemoteModeChange);
+        SubscribeLocalEvent<DoorRemoteComponent, GetVerbsEvent<AlternativeVerb>>(OnAddSwitchModeVerb);
         SubscribeLocalEvent<DoorRemoteComponent, BeforeRangedInteractEvent>(OnBeforeInteract);
+    }
+
+    private void OnAddSwitchModeVerb(Entity<DoorRemoteComponent> remote, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract || !args.Using.HasValue)
+            return;
+
+        var user = args.User;
+        AlternativeVerb verb = new()
+        {
+            Text = Loc.GetString("door-remote-switch-mode"),
+            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/settings.svg.192dpi.png")),
+            Act = () => SwitchMode(remote, user),
+            Impact = LogImpact.Low
+        };
+        args.Verbs.Add(verb);
     }
 
     private void OnDoorRemoteModeChange(Entity<DoorRemoteComponent> ent, ref DoorRemoteModeChangeMessage args)
     {
         ent.Comp.Mode = args.Mode;
         Dirty(ent);
+    }
+
+    private void SwitchMode(Entity<DoorRemoteComponent> remote, EntityUid? userUid)
+    {
+        if (!userUid.HasValue)
+            return;
+        // Could add a delay/hold-off here to avoid a ton of network events if someone changes quickly
+        remote.Comp.Mode = remote.Comp.Mode switch // Clockwise rotation on the menu
+        {
+            OperatingMode.ToggleEmergencyAccess => OperatingMode.ToggleBolts,
+            OperatingMode.ToggleBolts => OperatingMode.OpenClose,
+            OperatingMode.OpenClose => OperatingMode.ToggleEmergencyAccess,
+            _ => OperatingMode.OpenClose
+        };
+        Dirty(remote);
     }
 
     private void OnBeforeInteract(Entity<DoorRemoteComponent> entity, ref BeforeRangedInteractEvent args)

--- a/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
+++ b/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
@@ -45,7 +45,7 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
             return;
 
         var user = args.User;
-        AlternativeVerb verb = new()
+        AlternativeVerb verb = new() // alt verb definition based on t-ray scanner implementation
         {
             Text = Loc.GetString("door-remote-switch-mode"),
             Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/settings.svg.192dpi.png")),

--- a/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
+++ b/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
@@ -10,11 +10,11 @@ using Content.Shared.Popups;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.Remotes.Components;
 using Content.Shared.Tag;
-using Content.Shared.Verbs;
+using Content.Shared.Verbs; // SV changes: Door remote alt verb
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
-using Robust.Shared.Utility;
+using Robust.Shared.Utility; // SV changes: Door remote alt verb
 
 namespace Content.Shared.Remotes.EntitySystems;
 
@@ -35,10 +35,10 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<DoorRemoteComponent, DoorRemoteModeChangeMessage>(OnDoorRemoteModeChange);
-        SubscribeLocalEvent<DoorRemoteComponent, GetVerbsEvent<AlternativeVerb>>(OnAddSwitchModeVerb);
+        SubscribeLocalEvent<DoorRemoteComponent, GetVerbsEvent<AlternativeVerb>>(OnAddSwitchModeVerb); // SV changes: Door remote alt verb
         SubscribeLocalEvent<DoorRemoteComponent, BeforeRangedInteractEvent>(OnBeforeInteract);
     }
-
+    // Begin SV changes: Door remote alt verb, based on other examples such as t-ray (mainly) and eshotgun (secondary)
     private void OnAddSwitchModeVerb(Entity<DoorRemoteComponent> remote, ref GetVerbsEvent<AlternativeVerb> args)
     {
         if (!args.CanAccess || !args.CanInteract || !args.Using.HasValue)
@@ -53,8 +53,7 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
             Impact = LogImpact.Low
         };
         args.Verbs.Add(verb);
-    }
-
+    } // end SV Changes: Door remote alt verb
     private void OnDoorRemoteModeChange(Entity<DoorRemoteComponent> ent, ref DoorRemoteModeChangeMessage args)
     {
         ent.Comp.Mode = args.Mode;

--- a/Resources/Locale/en-US/door-remote/door-remote.ftl
+++ b/Resources/Locale/en-US/door-remote/door-remote.ftl
@@ -5,6 +5,9 @@ door-remote-toggle-bolt-text = Toggles Bolts
 door-remote-emergency-access-text = Toggles Emergency Access
 door-remote-invalid-text = Invalid
 door-remote-mode-label = Mode: [color=white]{$modeString}[/color]
+door-remote-switch-mode = Switch mode
+door-remote-item-status-label = Mode: {$mode}
+    Switch: {$keybinding}
 
 ## Entity
 

--- a/Resources/Locale/en-US/door-remote/door-remote.ftl
+++ b/Resources/Locale/en-US/door-remote/door-remote.ftl
@@ -5,10 +5,11 @@ door-remote-toggle-bolt-text = Toggles Bolts
 door-remote-emergency-access-text = Toggles Emergency Access
 door-remote-invalid-text = Invalid
 door-remote-mode-label = Mode: [color=white]{$modeString}[/color]
+# Begin SV changes
 door-remote-switch-mode = Switch mode
 door-remote-item-status-label = Mode: {$mode}
     Switch: {$keybinding}
-
+# End SV changes
 ## Entity
 
 door-remote-switch-state-open-close = You switch the remote to open and close doors


### PR DESCRIPTION
<!-- New to Sector Vestige? Please read our CONTRIBUTING guide:
https://github.com/Sector-Vestige/Sector-Vestige/blob/master/CONTRIBUTING.md -->

## About the PR
<!--
What does this PR do?
Briefly summarize the changes, features, or fixes introduced.
-->
This PR adds an alternate verb interaction for the door remotes, allowing cycling through modes of operation using an alternate verb key bind.
## Why / Balance
<!--
Why was this change made?
- Does it fix a bug or issue? Link to the issue if applicable.
- Does it add a new feature? Explain the motivation.
- Does it affect game balance, gameplay design, or user experience? Explain how.
- Performance improvements? Describe the impact.
-->
 It's a nice use of the alternate verb system for something that has states that are cyclable.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
- [x] Launch into game and confirm operation in a single client-local server operation
## Media
<!--
Include screenshots or videos if this PR adds or changes anything visual.
If this PR is purely backend code or doesn't require visual demonstration, you can leave this section empty.
-->

https://github.com/user-attachments/assets/ee092548-9297-446c-bc74-c4510c3a968b


## Technical Details
<!--
Explain any significant code-level details or logic.
Mention refactors, edge cases, or anything maintainers should be aware of.
If this is a simple change, you can keep this brief or omit it.
-->
This PR implements an alternative verb event to cycle the door remote's mode and adds additional based on other implementations (namely t-ray and the e-shotgun). The event is currently spammable and a hold-off/time could be added upon request. 
## Breaking Changes
<!--
List any breaking changes to code structure or content.
This includes prototype name changes, class renames, or field changes that could affect downstream forks.
If there are none, write: "None"
-->
"None"
## Requirements
<!-- Confirm the following by placing an X inside each [ ] -->
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

<!-- PRs that do not meet these requirements may be delayed or closed. -->

## Changelog
<!--
List player-facing changes below using this exact format.
Only entries after the ':cl:' tag will be picked up by Weh Bot.

Valid types: add, remove, tweak, fix
Use lowercase only (e.g., 'add', not 'Add').

Example:
:cl:
- add: Added new medical scanner UI.
- fix: Fixed lockers not opening.
-->

:cl:
- add: In-hand alternate interaction to cycle door remote.
