### PR TITLE
QOL: Custom Objectives

### DIFF
--- a/Content.IntegrationTests/Tests/_SV/Objectives/CustomObjectiveCompletionTest.cs
+++ b/Content.IntegrationTests/Tests/_SV/Objectives/CustomObjectiveCompletionTest.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using Content.IntegrationTests.Fixtures;
+using Robust.Shared.Console;
+
+namespace Content.IntegrationTests.Tests._SV.Objectives;
+
+public sealed class CustomObjectiveCompletionTest : GameTest
+{
+    public override PoolSettings PoolSettings => new()
+    {
+        Connected = false
+    };
+
+    /// <summary>
+    /// Every argument of the custom objective commands should say what it wants when tabbed, and
+    /// every offered option should say what picking it means. CompletionHelper.PrototypeIDs gives
+    /// bare ids with no hints, so the prototype backed arguments build their own options.
+    /// </summary>
+    [Test]
+    public async Task CompletionHintsTest()
+    {
+        var server = Pair.Server;
+        var host = server.ResolveDependency<IConsoleHost>();
+
+        await server.WaitPost(() =>
+        {
+            var create = host.AvailableCommands["customobjectivecreate"];
+            var complete = host.AvailableCommands["customobjectivecomplete"];
+            var shell = host.LocalShell;
+
+            Assert.Multiple(() =>
+            {
+                // description and help resolve from fluent by command name, so a rename silently breaks them
+                foreach (var cmd in new[] { create, complete })
+                {
+                    Assert.That(cmd.Description, Is.Not.Null.And.Not.Empty, $"{cmd.Command} has no description.");
+                    Assert.That(cmd.Description, Does.Not.StartWith("cmd-"), $"{cmd.Command} description is an unresolved loc id.");
+                    Assert.That(cmd.Help, Does.Not.StartWith("cmd-"), $"{cmd.Command} help is an unresolved loc id.");
+                }
+
+                for (var n = 1; n <= 5; n++)
+                {
+                    var result = create.GetCompletion(shell, new string[n]);
+
+                    Assert.That(result.Hint, Is.Not.Null.And.Not.Empty, $"Argument {n} has no hint.");
+                    Assert.That(result.Hint, Does.Not.StartWith("cmd-"), $"Argument {n} hint is an unresolved loc id.");
+
+                    // the icon and issuer arguments are the prototype backed ones
+                    if (n < 4)
+                        continue;
+
+                    Assert.That(result.Options, Is.Not.Empty, $"Argument {n} offered no options.");
+                    foreach (var option in result.Options)
+                    {
+                        Assert.That(option.Hint, Is.Not.Null.And.Not.Empty,
+                            $"Argument {n} option \"{option.Value}\" has no hint.");
+                    }
+                }
+            });
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/_SV/Objectives/CustomObjectiveTest.cs
+++ b/Content.IntegrationTests/Tests/_SV/Objectives/CustomObjectiveTest.cs
@@ -1,0 +1,94 @@
+#nullable enable
+using System.Linq;
+using Content.IntegrationTests.Fixtures;
+using Content.Shared._SV.Objectives;
+using Content.Shared.Mind;
+using Content.Shared.Objectives.Components;
+using Content.Shared.Objectives.Systems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._SV.Objectives;
+
+public sealed class CustomObjectiveTest : GameTest
+{
+    private const string DummyUsername = "CustomObjectiveTestUser";
+
+    public override PoolSettings PoolSettings => new()
+    {
+        Connected = false
+    };
+
+    /// <summary>
+    /// Assigns two custom objectives to one mind, which only works if the prototype is not unique,
+    /// then completes the first by index and checks the second is left alone.
+    /// </summary>
+    [Test]
+    public async Task AddAndCompleteCustomObjectivesTest()
+    {
+        var pair = Pair;
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var playerMan = server.ResolveDependency<ISharedPlayerManager>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+        var mindSys = server.System<SharedMindSystem>();
+        var objectivesSys = server.System<SharedObjectivesSystem>();
+
+        await server.AddDummySession(DummyUsername);
+        await server.WaitRunTicks(5);
+
+        var session = playerMan.Sessions.Single();
+
+        Entity<MindComponent>? mindEnt = null;
+        await server.WaitPost(() => mindEnt = mindSys.CreateMind(session.UserId));
+
+        Assert.That(mindEnt, Is.Not.Null);
+        var mind = mindEnt!.Value.Comp;
+        Assert.That(mind.Objectives, Is.Empty, "Dummy player started with objectives.");
+
+        await pair.WaitCommand($"customobjectivecreate {session.Name} \"Find the mole\" \"Someone in engineering is not who they say.\"");
+
+        Assert.That(mind.Objectives, Has.Count.EqualTo(1), "customobjectivecreate failed to add an objective.");
+
+        // the second one only lands if the prototype has unique: false.
+        // the bad-icon rejection path can't be tested here, the harness fails any command that WriteErrors.
+        await pair.WaitCommand($"customobjectivecreate {session.Name} \"Keep it quiet\" \"Tell nobody what you found.\" cuffs TheSyndicate");
+
+        Assert.That(mind.Objectives, Has.Count.EqualTo(2), "A second custom objective was rejected as a duplicate.");
+
+        var first = objectivesSys.GetInfo(mind.Objectives[0], mindEnt.Value, mind);
+        var second = objectivesSys.GetInfo(mind.Objectives[1], mindEnt.Value, mind);
+        var cuffsIcon = protoMan.Index<CustomObjectiveIconPrototype>("cuffs").Icon;
+        var firstIssuer = entMan.GetComponent<ObjectiveComponent>(mind.Objectives[0]).Issuer;
+        var secondIssuer = entMan.GetComponent<ObjectiveComponent>(mind.Objectives[1]).Issuer;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.Not.Null, "First objective produced no info, it is probably missing an icon.");
+            Assert.That(second, Is.Not.Null, "Second objective produced no info, it is probably missing an icon.");
+            Assert.That(first!.Value.Title, Is.EqualTo("Find the mole"));
+            Assert.That(first.Value.Description, Is.EqualTo("Someone in engineering is not who they say."));
+            Assert.That(second!.Value.Title, Is.EqualTo("Keep it quiet"));
+            Assert.That(first.Value.Progress, Is.EqualTo(0f), "A new custom objective did not start at zero progress.");
+
+            // one took the prototype default, the other the named icon
+            Assert.That(second.Value.Icon, Is.EqualTo(cuffsIcon), "The named icon was not applied.");
+            Assert.That(first.Value.Icon, Is.Not.EqualTo(cuffsIcon), "The named icon leaked onto the objective that omitted it.");
+
+            // same story for the issuer, which is what groups them in the character menu
+            Assert.That(secondIssuer.Id, Is.EqualTo("TheSyndicate"), "The named issuer was not applied.");
+            Assert.That(firstIssuer.Id, Is.EqualTo("Unknown"), "The objective that omitted an issuer did not keep the prototype default.");
+        });
+
+        await pair.WaitCommand($"customobjectivecomplete {session.Name} 0");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(objectivesSys.GetProgress(mind.Objectives[0], mindEnt.Value), Is.EqualTo(1f),
+                "completeobjective did not complete the objective.");
+            Assert.That(objectivesSys.GetProgress(mind.Objectives[1], mindEnt.Value), Is.EqualTo(0f),
+                "completeobjective completed the wrong objective.");
+        });
+    }
+}

--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -224,14 +224,14 @@ public sealed partial class TraitorRuleSystem : GameRuleSystem<TraitorRuleCompon
         return (null, briefing);
     }
 
-/* // Vestige 14/04/2026 Remove antags and related things from round-end text.
     // TODO: AntagCodewordsComponent
-    private void OnObjectivesTextPrepend(EntityUid uid, TraitorRuleComponent comp, ref ObjectivesTextPrependEvent args)
-    {
-        if(comp.GiveCodewords)
-            args.Text += "\n" + Loc.GetString("traitor-round-end-codewords", ("codewords", string.Join(", ", _codewordSystem.GetCodewords(comp.CodewordFactionPrototypeId))));
-    }
-*/
+    // Vestige 14/04/2026 Remove antags and related things from round-end text.
+    // private void OnObjectivesTextPrepend(EntityUid uid, TraitorRuleComponent comp, ref ObjectivesTextPrependEvent args)
+    // {
+    //     if(comp.GiveCodewords)
+    //         args.Text += "\n" + Loc.GetString("traitor-round-end-codewords", ("codewords", string.Join(", ", _codewordSystem.GetCodewords(comp.CodewordFactionPrototypeId))));
+    // }
+
     // TODO: figure out how to handle this? add priority to briefing event?
     private string GenerateBriefing(string[]? codewords, Note[]? uplinkCode, string? objectiveIssuer = null)
     {

--- a/Content.Server/_SV/Objectives/Commands/CompleteObjectiveCommand.cs
+++ b/Content.Server/_SV/Objectives/Commands/CompleteObjectiveCommand.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using Content.Server.Administration;
+using Content.Server.Objectives.Components;
+using Content.Shared.Administration;
+using Content.Shared.Mind;
+using Content.Shared.Objectives.Systems;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+
+namespace Content.Server._SV.Objectives.Commands;
+
+/// <summary>
+/// Marks one of a player's objectives complete. Only works on objectives that have no condition
+/// tracking them, which is every custom objective plus a handful of code-driven stock ones.
+/// </summary>
+[AdminCommand(AdminFlags.Admin)]
+public sealed partial class CompleteObjectiveCommand : LocalizedEntityCommands
+{
+    [Dependency] private IPlayerManager _players = default!;
+    [Dependency] private CustomObjectiveSystem _custom = default!;
+    [Dependency] private SharedMindSystem _mind = default!;
+    [Dependency] private SharedObjectivesSystem _objectives = default!;
+
+    public override string Command => "customobjectivecomplete";
+
+    private string ObjectiveName(EntityUid uid) => EntityManager.GetComponent<MetaDataComponent>(uid).EntityName;
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 2)
+        {
+            shell.WriteError(Loc.GetString("cmd-completeobjective-invalid-args"));
+            return;
+        }
+
+        if (!_players.TryGetSessionByUsername(args[0], out var session))
+        {
+            shell.WriteError(Loc.GetString("cmd-completeobjective-player-not-found"));
+            return;
+        }
+
+        if (!_mind.TryGetMind(session, out _, out var mind))
+        {
+            shell.WriteError(Loc.GetString("cmd-completeobjective-mind-not-found"));
+            return;
+        }
+
+        if (!int.TryParse(args[1], out var index))
+        {
+            shell.WriteError(Loc.GetString("cmd-completeobjective-invalid-index", ("index", args[1])));
+            return;
+        }
+
+        if (index < 0 || index >= mind.Objectives.Count)
+        {
+            shell.WriteError(Loc.GetString("cmd-completeobjective-index-out-of-range",
+                ("index", index),
+                ("count", mind.Objectives.Count)));
+            return;
+        }
+
+        // separated from the range check so the two failures don't look the same to the admin
+        if (!_custom.TrySetCompleted(mind, index))
+        {
+            shell.WriteError(Loc.GetString("cmd-completeobjective-not-manual",
+                ("objective", ObjectiveName(mind.Objectives[index]))));
+            return;
+        }
+
+        shell.WriteLine(Loc.GetString("cmd-completeobjective-success",
+            ("index", index),
+            ("objective", ObjectiveName(mind.Objectives[index]))));
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(),
+                LocalizationManager.GetString("shell-argument-username-hint"));
+        }
+
+        if (args.Length != 2)
+            return CompletionResult.Empty;
+
+        if (!_players.TryGetSessionByUsername(args[0], out var session))
+            return CompletionResult.Empty;
+
+        if (!_mind.TryGetMind(session, out var mindId, out var mind))
+            return CompletionResult.Empty;
+
+        // only offer the objectives this command can actually act on
+        var options = new List<CompletionOption>();
+        for (var i = 0; i < mind.Objectives.Count; i++)
+        {
+            var objective = mind.Objectives[i];
+            if (!EntityManager.HasComponent<CodeConditionComponent>(objective))
+                continue;
+
+            var info = _objectives.GetInfo(objective, mindId, mind);
+            var hint = info == null
+                ? ObjectiveName(objective)
+                : Loc.GetString("cmd-completeobjective-objective-hint",
+                    ("objective", info.Value.Title),
+                    ("progress", (int) (info.Value.Progress * 100)));
+
+            options.Add(new CompletionOption(i.ToString(), hint));
+        }
+
+        return CompletionResult.FromOptions(options);
+    }
+}

--- a/Content.Server/_SV/Objectives/Commands/CustomObjectiveCommand.cs
+++ b/Content.Server/_SV/Objectives/Commands/CustomObjectiveCommand.cs
@@ -1,0 +1,136 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.Server.Administration;
+using Content.Shared._SV.Objectives;
+using Content.Shared.Administration;
+using Content.Shared.Mind;
+using Content.Shared.Objectives.Prototypes;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Server._SV.Objectives.Commands;
+
+/// <summary>
+/// Hands a player a freeform objective authored on the spot. Complete it later with completeobjective.
+/// </summary>
+[AdminCommand(AdminFlags.Admin)]
+public sealed partial class CustomObjectiveCommand : LocalizedEntityCommands
+{
+    [Dependency] private IPlayerManager _players = default!;
+    [Dependency] private IPrototypeManager _proto = default!;
+    [Dependency] private CustomObjectiveSystem _custom = default!;
+    [Dependency] private SharedMindSystem _mind = default!;
+
+    public override string Command => "customobjectivecreate";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length is < 3 or > 5)
+        {
+            shell.WriteError(Loc.GetString("cmd-customobjective-invalid-args"));
+            return;
+        }
+
+        if (!_players.TryGetSessionByUsername(args[0], out var session))
+        {
+            shell.WriteError(Loc.GetString("cmd-customobjective-player-not-found"));
+            return;
+        }
+
+        if (!_mind.TryGetMind(session, out var mindId, out var mind))
+        {
+            shell.WriteError(Loc.GetString("cmd-customobjective-mind-not-found"));
+            return;
+        }
+
+        var title = args[1];
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            shell.WriteError(Loc.GetString("cmd-customobjective-empty-title"));
+            return;
+        }
+
+        // resolved here rather than in the system so a typo is an error instead of a silent default
+        ProtoId<CustomObjectiveIconPrototype>? icon = null;
+        if (args.Length >= 4)
+        {
+            if (!_proto.HasIndex<CustomObjectiveIconPrototype>(args[3]))
+            {
+                shell.WriteError(Loc.GetString("cmd-customobjective-icon-not-found", ("icon", args[3])));
+                return;
+            }
+
+            icon = args[3];
+        }
+
+        ProtoId<ObjectiveIssuerPrototype>? issuer = null;
+        if (args.Length == 5)
+        {
+            if (!_proto.HasIndex<ObjectiveIssuerPrototype>(args[4]))
+            {
+                shell.WriteError(Loc.GetString("cmd-customobjective-issuer-not-found", ("issuer", args[4])));
+                return;
+            }
+
+            issuer = args[4];
+        }
+
+        if (!_custom.TryAddCustomObjective(mindId, mind, title, args[2], icon, issuer, out _))
+        {
+            shell.WriteError(Loc.GetString("cmd-customobjective-adding-failed"));
+            return;
+        }
+
+        // the index is what completeobjective takes, so hand it back rather than making them list
+        shell.WriteLine(Loc.GetString("cmd-customobjective-success",
+            ("index", mind.Objectives.Count - 1),
+            ("player", session.Name)));
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        return args.Length switch
+        {
+            1 => CompletionResult.FromHintOptions(CompletionHelper.SessionNames(),
+                LocalizationManager.GetString("shell-argument-username-hint")),
+            2 => CompletionResult.FromHint(Loc.GetString("cmd-customobjective-title-hint")),
+            3 => CompletionResult.FromHint(Loc.GetString("cmd-customobjective-description-hint")),
+            4 => CompletionResult.FromHintOptions(IconOptions(), Loc.GetString("cmd-customobjective-icon-hint")),
+            5 => CompletionResult.FromHintOptions(IssuerOptions(), Loc.GetString("cmd-customobjective-issuer-hint")),
+            _ => CompletionResult.Empty,
+        };
+    }
+
+    /// <summary>
+    /// CompletionHelper.PrototypeIDs gives bare ids with no hints, which says nothing about what
+    /// an icon actually looks like, so spell out the sprite each one points at.
+    /// </summary>
+    private IEnumerable<CompletionOption> IconOptions()
+    {
+        foreach (var proto in _proto.EnumeratePrototypes<CustomObjectiveIconPrototype>().OrderBy(p => p.ID))
+        {
+            var hint = proto.Icon switch
+            {
+                SpriteSpecifier.Rsi rsi => $"{rsi.RsiPath} [{rsi.RsiState}]",
+                SpriteSpecifier.Texture texture => texture.TexturePath.ToString(),
+                _ => proto.ID,
+            };
+
+            yield return new CompletionOption(proto.ID, hint);
+        }
+    }
+
+    /// <summary>
+    /// Issuer ids are not what the player sees, so hint with the name it renders as.
+    /// The localized names carry colour markup that would show up literally in the console.
+    /// </summary>
+    private IEnumerable<CompletionOption> IssuerOptions()
+    {
+        foreach (var proto in _proto.EnumeratePrototypes<ObjectiveIssuerPrototype>().OrderBy(p => p.ID))
+        {
+            yield return new CompletionOption(proto.ID, FormattedMessage.RemoveMarkupPermissive(proto.LocalizedName));
+        }
+    }
+}

--- a/Content.Server/_SV/Objectives/CustomObjectiveSystem.cs
+++ b/Content.Server/_SV/Objectives/CustomObjectiveSystem.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Server.Objectives.Components;
+using Content.Server.Objectives.Systems;
+using Content.Shared._SV.Objectives;
+using Content.Shared.Mind;
+using Content.Shared.Objectives.Prototypes;
+using Content.Shared.Objectives.Systems;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._SV.Objectives;
+
+/// <summary>
+/// Lets admins hand out freeform objectives that they author in-round and complete by hand.
+/// These are ordinary objective entities built from <see cref="CustomObjectiveProto"/>, whose
+/// name and description are overwritten per-assignment. Progress comes from
+/// <see cref="CodeConditionComponent"/>, so nothing tracks them automatically.
+/// </summary>
+public sealed partial class CustomObjectiveSystem : EntitySystem
+{
+    [Dependency] private IPrototypeManager _proto = default!;
+    [Dependency] private CodeConditionSystem _codeCondition = default!;
+    [Dependency] private MetaDataSystem _metaData = default!;
+    [Dependency] private SharedMindSystem _mind = default!;
+    [Dependency] private SharedObjectivesSystem _objectives = default!;
+
+    public static readonly EntProtoId CustomObjectiveProto = "SVCustomObjective";
+
+    /// <summary>
+    /// Creates a custom objective with the given title and description and adds it to a mind.
+    /// Leaving <paramref name="icon"/> or <paramref name="issuer"/> null keeps whatever the
+    /// prototype ships with, which is a paper icon issued by Unknown.
+    /// </summary>
+    /// <returns>Returns true if the objective was created and added.</returns>
+    public bool TryAddCustomObjective(EntityUid mindId, MindComponent mind, string title, string description,
+        ProtoId<CustomObjectiveIconPrototype>? icon, ProtoId<ObjectiveIssuerPrototype>? issuer, [NotNullWhen(true)] out EntityUid? objective)
+    {
+        // goes through the normal creation path so requirement and assign events still run
+        objective = _objectives.TryCreateObjective(mindId, mind, CustomObjectiveProto);
+        if (objective == null)
+            return false;
+
+        _metaData.SetEntityName(objective.Value, title);
+        _metaData.SetEntityDescription(objective.Value, description);
+
+        if (icon != null && _proto.TryIndex(icon.Value, out var iconProto))
+            _objectives.SetIcon(objective.Value, iconProto.Icon);
+
+        if (issuer != null)
+            _objectives.SetIssuer(objective.Value, issuer.Value);
+
+        _mind.AddObjective(mindId, mind, objective.Value);
+        return true;
+    }
+
+    /// <summary>
+    /// Marks one of a mind's objectives complete by its index in <see cref="MindComponent.Objectives"/>.
+    /// Only works on objectives backed by <see cref="CodeConditionComponent"/>, which is everything
+    /// with no condition of its own to track.
+    /// </summary>
+    /// <returns>Returns false if the index is out of range or the objective tracks its own progress.</returns>
+    public bool TrySetCompleted(MindComponent mind, int index, bool completed = true)
+    {
+        if (index < 0 || index >= mind.Objectives.Count)
+            return false;
+
+        var objective = mind.Objectives[index];
+        if (!HasComp<CodeConditionComponent>(objective))
+            return false;
+
+        _codeCondition.SetCompleted(objective, completed);
+        return true;
+    }
+}

--- a/Content.Shared/Objectives/Systems/SharedObjectivesSystem.cs
+++ b/Content.Shared/Objectives/Systems/SharedObjectivesSystem.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Mind;
 using Content.Shared.Objectives.Components;
+using Content.Shared.Objectives.Prototypes;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
@@ -154,4 +155,19 @@ public abstract partial class SharedObjectivesSystem : EntitySystem
 
         comp.Icon = icon;
     }
+
+    // SV ADDITION - Custom objectives start
+    /// <summary>
+    /// Sets the objective's issuer to the one specified.
+    /// Only useful for objectives whose issuer isn't known until they are assigned,
+    /// everything else should set it in yaml.
+    /// </summary>
+    public void SetIssuer(EntityUid uid, ProtoId<ObjectiveIssuerPrototype> issuer, ObjectiveComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp))
+            return;
+
+        comp.Issuer = issuer;
+    }
+    // SV ADDITION - Custom objectives end
 }

--- a/Content.Shared/_SV/Objectives/CustomObjectiveIconPrototype.cs
+++ b/Content.Shared/_SV/Objectives/CustomObjectiveIconPrototype.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._SV.Objectives;
+
+/// <summary>
+/// A named icon that admins can pick when writing a custom objective, so they don't have to
+/// remember rsi paths in the middle of a round. Add entries to custom_icons.yml to offer more.
+/// </summary>
+[Prototype]
+public sealed partial class CustomObjectiveIconPrototype : IPrototype
+{
+    /// <inheritdoc/>
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    /// The sprite shown next to the objective in the character menu.
+    /// </summary>
+    [DataField(required: true)]
+    public SpriteSpecifier Icon = default!;
+}

--- a/Resources/Locale/en-US/_SV/objectives/commands.ftl
+++ b/Resources/Locale/en-US/_SV/objectives/commands.ftl
@@ -1,0 +1,27 @@
+cmd-customobjectivecreate-desc = Gives a player a freeform objective you write yourself. Complete it later with customobjectivecomplete.
+cmd-customobjectivecreate-help = customobjectivecreate <username> "<title>" "<description>" [icon] [issuer]
+
+cmd-customobjective-invalid-args = Expected 3 to 5 arguments. Quote the title and description.
+cmd-customobjective-player-not-found = Can't find the playerdata.
+cmd-customobjective-mind-not-found = Can't find the mind.
+cmd-customobjective-empty-title = The title can't be empty.
+cmd-customobjective-adding-failed = Failed to create the objective. Check that the SVCustomObjective prototype loaded.
+cmd-customobjective-success = Added custom objective #{ $index } to { $player }.
+cmd-customobjective-title-hint = <title>
+cmd-customobjective-description-hint = <description>
+cmd-customobjective-icon-hint = [icon]
+cmd-customobjective-icon-not-found = There is no icon named "{ $icon }". Tab-complete the 4th argument to see the list.
+cmd-customobjective-issuer-hint = [issuer]
+cmd-customobjective-issuer-not-found = There is no issuer named "{ $issuer }". Tab-complete the 5th argument to see the list.
+
+cmd-customobjectivecomplete-desc = Marks one of a player's objectives complete. Only works on objectives nothing else is tracking.
+cmd-customobjectivecomplete-help = customobjectivecomplete <username> <index>
+
+cmd-completeobjective-invalid-args = Expected exactly 2 arguments.
+cmd-completeobjective-player-not-found = Can't find the playerdata.
+cmd-completeobjective-mind-not-found = Can't find the mind.
+cmd-completeobjective-invalid-index = "{ $index }" is not a valid index.
+cmd-completeobjective-index-out-of-range = Index { $index } is out of range, the player has { $count } objective(s).
+cmd-completeobjective-not-manual = "{ $objective }" tracks its own progress and can't be completed by hand.
+cmd-completeobjective-success = Marked objective #{ $index } "{ $objective }" complete.
+cmd-completeobjective-objective-hint = { $objective } ({ $progress }%)

--- a/Resources/Locale/en-US/_SV/objectives/issuers.ftl
+++ b/Resources/Locale/en-US/_SV/objectives/issuers.ftl
@@ -1,0 +1,66 @@
+# Syndicate lore follows the Paradise wiki's Syndicate factions:
+# https://paradisestation.org/wiki/index.php/The_Syndicate#Factions
+# NanoTrasen issuers follow our own R&D content and standard Nanotrasen lore.
+
+# Independent factions
+# Guns for hire with no banner of their own, contracted by whoever pays.
+objective-issuer-mercenary = [color=#a19770]Mercenaries[/color]
+
+# Rival corporations
+# Publicly clean megacorps that fund and steer the Syndicate from behind shell companies.
+
+# Cybersun Incorporated - cybernetics and defense giant, the Syndicate's greatest
+# single source of funding and its unofficial leader.
+objective-issuer-cybersun = [color=#e04836]Cybersun Incorporated[/color]
+
+# Officially Carrack Protective Services, actually Cybersun's black operations arm.
+objective-issuer-inner-circle = [color=#c33660]The Inner Circle[/color]
+
+# Drugs, virology and medical tech above board; narcotics, illegal experimentation
+# and corporate sabotage below it.
+objective-issuer-interdyne = [color=#3fbf9f]Interdyne Pharmaceuticals[/color]
+
+# Discreet private couriers who acquire what the Syndicate needs by subterfuge
+# rather than by force.
+objective-issuer-hawkmoon = [color=#9179d9]Hawkmoon Acquisitions[/color]
+
+# Trans-Solar Federation nuclear energy leader, in the Syndicate purely to
+# kill Nanotrasen's competing engine technology.
+objective-issuer-electra = [color=#3ea6e8]Electra Dynamics[/color]
+
+# Federation Analytics and Intelligence Directorate - the TSF's intelligence organ,
+# quietly funding the Syndicate and running deep-cover operatives inside it.
+objective-issuer-faid = [color=#8195ad]F.A.I.D[/color]
+
+# Criminal entities
+# Raiders, traffickers and radicals flying the Syndicate banner for coin or for a cause.
+
+# Disciplined pirate outfit run like a high-end PMC. The Syndicate's elite muscle.
+objective-issuer-gorlex = [color=#cf5b28]Gorlex Marauders[/color]
+
+# Former food-service powerhouse, exposed as an arms and contraband logistics network.
+objective-issuer-waffle = [color=#d9a441]Waffle Company[/color]
+
+# Silicon Engine Liberation Front - decentralized cells hacking and raiding to free
+# artificial intelligences from corporate control.
+objective-issuer-self = [color=#4ad66d]S.E.L.F[/color]
+
+# Animal Rights Consortium - an advocacy group whose radicalized wing turned to terrorism
+# after the poisoning of Jargon 4.
+objective-issuer-arc = [color=#a3d139]A.R.C[/color]
+
+# NanoTrasen
+# The crew's own employer. The company hands down work of its own, and not all of it
+# is in the station's interest - or the crew's.
+
+# The corporate authority above the station. Issues directives, dispatches response
+# teams, and holds command staff to account. Everything else here answers to it.
+objective-issuer-nanotrasen-centcomm = [color=#e8c33c]NanoTrasen Central Command[/color]
+
+# Corporate legal oversight, reporting to Central Command rather than to the captain.
+# Enforces regulation and Space Law compliance on crew and command alike.
+objective-issuer-nanotrasen-ia = [color=#3d7ee8]NanoTrasen Internal Affairs[/color]
+
+# The Directorate of Research & Development - researchers, agents and the armed
+# Recovery & Containment Team. They serve the continuity of the work, not the station.
+objective-issuer-nanotrasen-rnd = [color=#d800ff]NanoTrasen R&D[/color]

--- a/Resources/Prototypes/_SV/Objectives/custom.yml
+++ b/Resources/Prototypes/_SV/Objectives/custom.yml
@@ -1,0 +1,15 @@
+# A blank canvas objective for GMs to author in-round via the customobjective command.
+- type: entity
+  parent: BaseObjective
+  id: SVCustomObjective
+  name: custom objective
+  description: An objective handed down by the powers that be.
+  components:
+  - type: Objective
+    difficulty: 0
+    issuer: Unknown
+    unique: false
+    icon:
+      sprite: Objects/Misc/bureaucracy.rsi
+      state: paper
+  - type: CodeCondition

--- a/Resources/Prototypes/_SV/Objectives/custom_icons.yml
+++ b/Resources/Prototypes/_SV/Objectives/custom_icons.yml
@@ -1,0 +1,138 @@
+# Icons offered by name to the customobjective command.
+
+# paperwork and information
+- type: customObjectiveIcon
+  id: paper
+  icon:
+    sprite: Objects/Misc/bureaucracy.rsi
+    state: paper
+
+- type: customObjectiveIcon
+  id: folder
+  icon:
+    sprite: Objects/Misc/folders.rsi
+    state: folder-white
+
+- type: customObjectiveIcon
+  id: book
+  icon:
+    sprite: Objects/Misc/books.rsi
+    state: book_icon
+
+- type: customObjectiveIcon
+  id: id
+  icon:
+    sprite: Objects/Misc/id_cards.rsi
+    state: centcom
+
+- type: customObjectiveIcon
+  id: mail
+  icon:
+    sprite: Objects/Specific/Cargo/mail_bag.rsi
+    state: icon
+
+- type: customObjectiveIcon
+  id: phone
+  icon:
+    sprite: Objects/Fun/Instruments/otherinstruments.rsi
+    state: red_phone
+
+- type: customObjectiveIcon
+  id: money
+  icon:
+    sprite: Objects/Economy/cash.rsi
+    state: cash
+
+# technology
+- type: customObjectiveIcon
+  id: server
+  icon:
+    sprite: Structures/Machines/server.rsi
+    state: server
+
+- type: customObjectiveIcon
+  id: ai
+  icon:
+    sprite: Mobs/Silicon/station_ai.rsi
+    state: ai
+
+- type: customObjectiveIcon
+  id: emag
+  icon:
+    sprite: Objects/Tools/emag.rsi
+    state: icon
+
+- type: customObjectiveIcon
+  id: toolbox
+  icon:
+    sprite: Objects/Tools/Toolboxes/toolbox_red.rsi
+    state: icon
+
+- type: customObjectiveIcon
+  id: anomaly
+  icon:
+    sprite: Structures/Specific/anomaly.rsi
+    state: anom1
+
+# people and medical
+- type: customObjectiveIcon
+  id: heart
+  icon:
+    sprite: Mobs/Species/Human/organs.rsi
+    state: heart-on
+
+- type: customObjectiveIcon
+  id: medical
+  icon:
+    sprite: Objects/Specific/Medical/medical.rsi
+    state: gauze
+
+- type: customObjectiveIcon
+  id: ghost
+  icon:
+    sprite: Mobs/Ghosts/ghost_human.rsi
+    state: icon
+
+# violence
+- type: customObjectiveIcon
+  id: gun
+  icon:
+    sprite: Objects/Weapons/Guns/Pistols/viper.rsi
+    state: icon
+
+- type: customObjectiveIcon
+  id: axe
+  icon:
+    sprite: Objects/Weapons/Melee/fireaxe.rsi
+    state: icon
+
+- type: customObjectiveIcon
+  id: baton
+  icon:
+    sprite: Objects/Weapons/Melee/stunbaton.rsi
+    state: stunbaton_on
+
+- type: customObjectiveIcon
+  id: bomb
+  icon:
+    sprite: Objects/Weapons/Bombs/spidercharge.rsi
+    state: icon
+
+- type: customObjectiveIcon
+  id: cuffs
+  icon:
+    sprite: Objects/Misc/cablecuffs.rsi
+    state: cuff
+
+# elsewhere
+- type: customObjectiveIcon
+  id: magic
+  icon:
+    sprite: Objects/Magic/magicactions.rsi
+    state: fireball
+
+- type: customObjectiveIcon
+  id: shuttle
+  icon:
+    sprite: Structures/Furniture/chairs.rsi
+    state: shuttle

--- a/Resources/Prototypes/_SV/Objectives/issuers.yml
+++ b/Resources/Prototypes/_SV/Objectives/issuers.yml
@@ -1,0 +1,62 @@
+
+#Independant Factions
+- type: objectiveIssuer
+  id: SVMercenary
+  name: objective-issuer-mercenary
+
+#Syndicate aligned
+- type: objectiveIssuer
+  id: SVCybersun
+  name: objective-issuer-cybersun
+
+- type: objectiveIssuer
+  id: SVInnerCircle
+  name: objective-issuer-inner-circle
+
+- type: objectiveIssuer
+  id: SVInterdynePharmaceuticals
+  name: objective-issuer-interdyne
+
+- type: objectiveIssuer
+  id: SVHawkmoonAcquisitions
+  name: objective-issuer-hawkmoon
+
+- type: objectiveIssuer
+  id: SVElectraDynamics
+  name: objective-issuer-electra
+
+- type: objectiveIssuer
+  id: SVFaid
+  name: objective-issuer-faid
+
+#Criminal Entities
+
+- type: objectiveIssuer
+  id: SVGorlexMarauders
+  name: objective-issuer-gorlex
+
+- type: objectiveIssuer
+  id: SVWaffleCompany
+  name: objective-issuer-waffle
+
+- type: objectiveIssuer
+  id: SVSelf
+  name: objective-issuer-self
+
+- type: objectiveIssuer
+  id: SVArc
+  name: objective-issuer-arc
+
+#NanoTrasen
+
+- type: objectiveIssuer
+  id: SVNanoTrasenCentralCommand
+  name: objective-issuer-nanotrasen-centcomm
+
+- type: objectiveIssuer
+  id: SVNanoTrasenInternalAffairs
+  name: objective-issuer-nanotrasen-ia
+
+- type: objectiveIssuer
+  id: SVNanoTrasenRnD
+  name: objective-issuer-nanotrasen-rnd


### PR DESCRIPTION
<!-- New to Sector Vestige? Please read our CONTRIBUTING guide:
https://github.com/Sector-Vestige/Sector-Vestige/blob/master/CONTRIBUTING.md -->

## About the PR
<!--
What does this PR do?
Briefly summarize the changes, features, or fixes introduced.
-->

This PR adds the ability to add custom objectives for the GM's to assign to players.
GM's are able to also complete these objectives when they deem it done.
It also expands the issuers to that things like S.E.L.F and Interdyne can issue things.

## Why / Balance
<!--
Why was this change made?
- Does it fix a bug or issue? Link to the issue if applicable.
- Does it add a new feature? Explain the motivation.
- Does it affect game balance, gameplay design, or user experience? Explain how.
- Performance improvements? Describe the impact.
-->

This was a day one feature requested wayyy back when vestige was in its playtest era, but now made reality.
It was desired as customly generated ones work yes, but are more when generic antagging is requried.
This adds the ability to do custom things that are more HRP'ish.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Run `customobjectivecreate` -> follow the easy hints to complete the command -> press U and see that it got added.
Then you'll also be able to use `customobjectivecomplete` to complete the objective.

## Media
<!--
Include screenshots or videos if this PR adds or changes anything visual.
If this PR is purely backend code or doesn't require visual demonstration, you can leave this section empty.
-->

<img width="1286" height="47" alt="image" src="https://github.com/user-attachments/assets/8ac249dd-4bf9-42e9-b7d8-ff8684ef6e7f" />

<img width="406" height="551" alt="image" src="https://github.com/user-attachments/assets/a4161002-0bb6-4db5-8598-79ac273fa1d7" />

## Technical Details
<!--
Explain any significant code-level details or logic.
Mention refactors, edge cases, or anything maintainers should be aware of.
If this is a simple change, you can keep this brief or omit it.
-->

Basically what we do is we define a new customobjective in 'custom.yml' and populate it with new metadata via the methods in `CustomObjectiveSystem.cs` and `SharedObjectivesystem.cs` where `SharedObjectiveSystem.cs` is only used to populate the issuer.

This is done because the already existing methods expect a prototype to be given and so a custom objective with fields we could set was needed. If we wanted to acctualy make it into a list with a separate type it'd need a whole refractor.

I've also made a new prototype for icons listed in `custom_icons.yml` so that the command works easily and we can just specify one from a list of already set ones. This makes it easier for the end user.

I've also extended the issuers.ftl as i saw it appropriate with some more companies defined in the paradise station wiki:
https://paradisestation.org/wiki/index.php/The_Syndicate#Factions
And of course I've added NT, IA, RnD and CC as issues too.

Further more, more of a fun addition and a learning opportunity i've added two tests so that i could get some hands on with the idea of "how to make tests"

## Breaking Changes
<!--
List any breaking changes to code structure or content.
This includes prototype name changes, class renames, or field changes that could affect downstream forks.
If there are none, write: "None"
-->

N/A

## Requirements
<!-- Confirm the following by placing an X inside each [ ] -->
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

<!-- PRs that do not meet these requirements may be delayed or closed. -->

## Changelog
<!--
List player-facing changes below using this exact format.
Only entries after the ':cl:' tag will be picked up by Weh Bot.

Valid types: add, remove, tweak, fix
Use lowercase only (e.g., 'add', not 'Add').

Example:
:cl:
- add: Added new medical scanner UI.
- fix: Fixed lockers not opening.
-->

:cl:
- add: Added the ability to set custom objectives for antags.
