### PR TITLE
Fixes Bug: Document Editor does not respect close tags

### DIFF
--- a/Content.Shared/_SV/CharacterDocuments/CharacterDocumentMarkup.cs
+++ b/Content.Shared/_SV/CharacterDocuments/CharacterDocumentMarkup.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Sector-Vestige contributors
+// SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+// SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Collections.Generic;
 using Robust.Shared.Utility;
 

--- a/Content.Shared/_SV/CharacterDocuments/CharacterDocumentMarkup.cs
+++ b/Content.Shared/_SV/CharacterDocuments/CharacterDocumentMarkup.cs
@@ -11,9 +11,16 @@ public static class CharacterDocumentMarkup
 {
     /// <summary>
     ///     Parses <paramref name="content"/> permissively and returns a <see cref="FormattedMessage"/>
-    ///     whose tags are guaranteed to be balanced: unmatched closing tags are dropped and any tags
-    ///     left open at the end are closed. Safe to feed straight into a rich-text control.
+    ///     whose tags are guaranteed to be balanced: closing tags that never had a matching opening
+    ///     tag are dropped and any tags left open at the end are closed. Safe to feed straight into
+    ///     a rich-text control.
     /// </summary>
+    /// <remarks>
+    ///     Authors routinely overlap tags rather than nesting them properly — <c>[head]a[bold]b[/head]c[/bold]</c>
+    ///     is a perfectly clear intent even though it isn't well-formed. Such a closing tag is honoured
+    ///     where it was written by closing the tags opened after it, closing it, then reopening those
+    ///     tags, so only the tag the author closed stops applying.
+    /// </remarks>
     public static FormattedMessage BuildBalancedMessage(string? content)
     {
         FormattedMessage parsed;
@@ -31,9 +38,10 @@ public static class CharacterDocumentMarkup
         }
 
         var result = new FormattedMessage();
-        // Names of tags currently open, innermost last. Mirrors the FormattedMessage's own
-        // internal open-node stack so result.Pop() always closes the matching tag.
-        var open = new Stack<string>();
+        // Opening nodes currently open, innermost last. Mirrors the FormattedMessage's own
+        // internal open-node stack so result.Pop() always closes the matching tag, and keeps the
+        // original nodes around so a tag can be reopened with its attributes intact.
+        var open = new List<MarkupNode>();
 
         foreach (var node in parsed)
         {
@@ -47,26 +55,33 @@ public static class CharacterDocumentMarkup
             {
                 // Re-add the original opening node verbatim so colours/attributes are preserved.
                 result.PushTag(node);
-                open.Push(node.Name);
+                open.Add(node);
                 continue;
             }
 
-            // Only honour a closing tag if it actually closes the innermost open tag. A stray
-            // closer (no matching open, or improperly nested) is dropped rather than allowed to
-            // underflow the renderer's stack.
-            if (open.Count > 0 && open.Peek() == node.Name)
-            {
-                open.Pop();
+            // A closer with nothing to close would underflow the renderer's draw stack, so drop it.
+            var index = open.FindLastIndex(openNode => openNode.Name == node.Name);
+            if (index < 0)
+                continue;
+
+            // Unwind down to the tag being closed. Everything opened after it is still wanted by
+            // the author, so note it before closing and put it straight back afterwards.
+            var reopen = open.GetRange(index + 1, open.Count - index - 1);
+            for (var i = index; i < open.Count; i++)
                 result.Pop();
+
+            open.RemoveRange(index, open.Count - index);
+
+            foreach (var reopened in reopen)
+            {
+                result.PushTag(reopened);
+                open.Add(reopened);
             }
         }
 
         // Close anything the user left open, innermost first.
-        while (open.Count > 0)
-        {
-            open.Pop();
+        for (var i = open.Count - 1; i >= 0; i--)
             result.Pop();
-        }
 
         return result;
     }

--- a/Content.Tests/Shared/_SV/CharacterDocuments/CharacterDocumentMarkupTest.cs
+++ b/Content.Tests/Shared/_SV/CharacterDocuments/CharacterDocumentMarkupTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Content.Shared._SV.CharacterDocuments;
 using NUnit.Framework;
 using Robust.Shared.Utility;
@@ -55,6 +56,99 @@ public sealed class CharacterDocumentMarkupTest
     private static bool RenderWouldThrow(string markup)
         => RenderWouldThrow(FormattedMessage.FromMarkupPermissive(markup));
 
+    /// <summary>
+    ///     Describes which tags are actually in effect over each run of visible text, which is the
+    ///     behaviour a document author sees. Rendered as <c>'text'&lt;tag,tag&gt;</c> per run so a
+    ///     failure message reads like the document itself.
+    /// </summary>
+    private static string Describe(FormattedMessage message)
+    {
+        var runs = new List<string>();
+        var open = new List<string>();
+
+        foreach (var node in message)
+        {
+            if (node.Name == null)
+            {
+                runs.Add($"'{node.Value.StringValue}'<{string.Join(",", open)}>");
+                continue;
+            }
+
+            if (!node.Closing)
+            {
+                open.Add(node.Name);
+                continue;
+            }
+
+            var index = open.LastIndexOf(node.Name);
+            if (index >= 0)
+                open.RemoveAt(index);
+        }
+
+        return string.Join(" | ", runs);
+    }
+
+    private static string Describe(string markup)
+        => Describe(CharacterDocumentMarkup.BuildBalancedMessage(markup));
+
+    [Test]
+    public void OuterClosingTagEndsFormattingWhereItWasWritten()
+    {
+        // Issue #380: the tag opened first had its closer dropped and silently re-emitted at the
+        // end of the document, so the heading bled over every following paragraph.
+        Assert.That(Describe("[head=2][bold]Title[/head]body[/bold]"),
+            Is.EqualTo("'Title'<head,bold> | 'body'<bold>"));
+    }
+
+    [Test]
+    public void OverlappingTagsKeepTheStillOpenTagAlive()
+    {
+        // The inner tag has to be closed to close the outer one, then reopened so the author's
+        // remaining text keeps the formatting they asked for.
+        Assert.That(Describe("[bold][color=red]X[/bold]Y[/color]"),
+            Is.EqualTo("'X'<bold,color> | 'Y'<color>"));
+    }
+
+    [Test]
+    public void ReopenedTagsAreClosedAtTheEndOfTheDocument()
+    {
+        Assert.That(Describe("[bold][color=red]X[/bold]Y"),
+            Is.EqualTo("'X'<bold,color> | 'Y'<color>"));
+    }
+
+    [Test]
+    public void StrayClosingTagForANeverOpenedTagIsStillDropped()
+    {
+        Assert.That(Describe("[/head]text"), Is.EqualTo("'text'<>"));
+    }
+
+    [Test]
+    public void EveryClosingTagAppliesWhenTagsAreClosedInOpeningOrder()
+    {
+        // The exact shape reported in issue #380: closing in the order the tags were opened meant
+        // only the innermost tag ([color]) actually closed, and [head]/[bold] ran on to the end.
+        Assert.That(Describe("[head=2][bold][color=red]text[/head][/bold][/color]after"),
+            Is.EqualTo("'text'<head,bold,color> | 'after'<>"));
+    }
+
+    [Test]
+    public void SavedMarkupKeepsTheClosingTagWhereTheAuthorPutIt()
+    {
+        // Documents are rebalanced on the save path, so this is the markup the author gets back
+        // when they reopen the document. Issue #380: the [/head] used to reappear at the very end.
+        Assert.That(CharacterDocumentMarkup.Balance("[head=2][bold]Title[/head]body[/bold]"),
+            Is.EqualTo("[head=2][bold]Title[/bold][/head][bold]body[/bold]"));
+    }
+
+    [Test]
+    public void RebalancedOverlappingMarkupIsIdempotent()
+    {
+        const string raw = "[head=2][bold]Title[/head]body[/bold]";
+        var once = CharacterDocumentMarkup.Balance(raw);
+        var twice = CharacterDocumentMarkup.Balance(once);
+        Assert.That(twice, Is.EqualTo(once));
+    }
+
     [Test]
     public void RawDoubleClosingColorReproducesTheCrash()
     {
@@ -71,6 +165,9 @@ public sealed class CharacterDocumentMarkupTest
     [TestCase("[/font][/font]")]
     [TestCase("[color=red]unterminated")]
     [TestCase("[color=red][font]bad nesting[/color][/font]")]
+    [TestCase("[head=2][bold]Title[/head]body[/bold]")]
+    [TestCase("[bold][color=red]X[/bold]Y")]
+    [TestCase("[color=red][color=green]X[/color][/color][/color]")]
     [TestCase("")]
     [TestCase("plain document text, no tags")]
     [TestCase("[color=#ff0000]valid[/color]")]

--- a/Content.Tests/Shared/_SV/CharacterDocuments/CharacterDocumentMarkupTest.cs
+++ b/Content.Tests/Shared/_SV/CharacterDocuments/CharacterDocumentMarkupTest.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Wizards Den contributors
+// SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+// SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+//
+// SPDX-License-Identifier: MIT
+
 using System.Collections.Generic;
 using System.Linq;
 using Content.Shared._SV.CharacterDocuments;


### PR DESCRIPTION
<!-- New to Sector Vestige? Please read our CONTRIBUTING guide:
https://github.com/Sector-Vestige/Sector-Vestige/blob/master/CONTRIBUTING.md -->

## About the PR
<!--
What does this PR do?
Briefly summarize the changes, features, or fixes introduced.
-->

it fixes #380

## Why / Balance
<!--
Why was this change made?
- Does it fix a bug or issue? Link to the issue if applicable.
- Does it add a new feature? Explain the motivation.
- Does it affect game balance, gameplay design, or user experience? Explain how.
- Performance improvements? Describe the impact.
-->

Because Rose said:
"I could close the color tag, the head and bold tags could not be closed."

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Repeat steps taken in issue #380 

## Media
<!--
Include screenshots or videos if this PR adds or changes anything visual.
If this PR is purely backend code or doesn't require visual demonstration, you can leave this section empty.
-->

N/A

## Technical Details
<!--
Explain any significant code-level details or logic.
Mention refactors, edge cases, or anything maintainers should be aware of.
If this is a simple change, you can keep this brief or omit it.
-->

CharacterDocumentMarkup.BuildBalancedMessage (Content.Shared/_SV/CharacterDocuments/CharacterDocumentMarkup.cs:57) only honoured a closing tag if it matched the innermost open tag. Any other closer was silently dropped, and the still-open tag got closed at the very end of the document instead

## Breaking Changes
<!--
List any breaking changes to code structure or content.
This includes prototype name changes, class renames, or field changes that could affect downstream forks.
If there are none, write: "None"
-->

N/A

## Requirements
<!-- Confirm the following by placing an X inside each [ ] -->
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

<!-- PRs that do not meet these requirements may be delayed or closed. -->

## Changelog
<!--
List player-facing changes below using this exact format.
Only entries after the ':cl:' tag will be picked up by Weh Bot.

Valid types: add, remove, tweak, fix
Use lowercase only (e.g., 'add', not 'Add').

Example:
:cl:
- add: Added new medical scanner UI.
- fix: Fixed lockers not opening.
-->

:cl:

