### PR TITLE
Add fingerprints back onto the PC

### DIFF
--- a/Content.Client/_SV/CharacterDocuments/UI/CharacterDocumentConsoleWindow.xaml
+++ b/Content.Client/_SV/CharacterDocuments/UI/CharacterDocumentConsoleWindow.xaml
@@ -35,29 +35,49 @@
                         <LineEdit Name="TitleInput" PlaceHolder="{Loc 'sv-document-console-title-input'}" VerticalAlignment="Top" HorizontalExpand="True" Editable="False"/>
                         <BoxContainer Orientation="Horizontal" Margin="0 5 0 0" HorizontalExpand="True" MinHeight="75" VerticalAlignment="Bottom" >
                             <Label Name="ControlPanelStatus"/>
-                            <!-- Left Control panel: document metadata in a bordered card. Widened so
-                                 values like "Central Command" don't clip to "Central co..". -->
-                            <PanelContainer StyleClasses="BorderedWindowPanel" MinWidth="355" MaxWidth="355" VerticalExpand="True" HorizontalAlignment="Left">
-                                <BoxContainer Orientation="Vertical" Margin="6 4 6 4">
-                                    <Label Text="{Loc 'sv-document-console-header-details'}" StyleClasses="LabelKeyText" Margin="0 0 0 4"/>
-                                    <BoxContainer>
-                                        <BoxContainer HorizontalAlignment="Left" Orientation="Vertical" Margin="0 0 8 0">
-                                            <Label Name="DocAuthorLabel" Text="{Loc 'sv-document-console-author-label'}"/>
-                                            <Label Name="DocLastEditedByLabel" Text="{Loc 'sv-document-console-editedby-label'}"/>
-                                            <Label Name="DocDateLabel" Text="{Loc 'sv-document-console-date-label'}"/>
-                                            <Label Name="DocSecurityStatusLabel" Text="{Loc 'sv-document-console-security-status-label'}" Visible="False"/>
-                                            <Label Name="DocSecurityReasonLabel" Text="{Loc 'sv-document-console-security-reason-label'}" Visible="False"/>
-                                        </BoxContainer>
-                                        <BoxContainer HorizontalExpand="True" Orientation="Vertical">
-                                            <Label Name="DocAuthorLabelValue" Text="{Loc 'sv-document-console-author-label-value-none'}" ClipText="True"/>
-                                            <Label Name="DocLastEditedByLabelValue" Text="{Loc 'sv-document-console-editedby-label-value-none'}" ClipText="True"/>
-                                            <Label Name="DocDateLabelValue" Text="{Loc 'sv-document-console-date-label-value-none'}" ClipText="True"/>
-                                            <Label Name="DocSecurityStatusLabelValue" Text="-" Visible="False" ClipText="True"/>
-                                            <Label Name="DocSecurityReasonLabelValue" Text="-" Visible="False" ClipText="True"/>
+                            <!-- Left column. Widened to 355 so values like "Central Command" don't clip to
+                                 "Central co..". Each card hugs its own rows; the security card stacks
+                                 underneath so the column fills the height of the actions card beside it
+                                 instead of leaving a band of background. -->
+                            <BoxContainer Orientation="Vertical" MinWidth="355" MaxWidth="355" VerticalAlignment="Top" HorizontalAlignment="Left">
+                                <PanelContainer StyleClasses="BorderedWindowPanel" HorizontalExpand="True">
+                                    <BoxContainer Orientation="Vertical" Margin="6 4 6 4">
+                                        <Label Text="{Loc 'sv-document-console-header-details'}" StyleClasses="LabelKeyText" Margin="0 0 0 4"/>
+                                        <BoxContainer>
+                                            <BoxContainer HorizontalAlignment="Left" Orientation="Vertical" Margin="0 0 8 0">
+                                                <Label Name="DocAuthorLabel" Text="{Loc 'sv-document-console-author-label'}"/>
+                                                <Label Name="DocLastEditedByLabel" Text="{Loc 'sv-document-console-editedby-label'}"/>
+                                                <Label Name="DocDateLabel" Text="{Loc 'sv-document-console-date-label'}"/>
+                                            </BoxContainer>
+                                            <BoxContainer HorizontalExpand="True" Orientation="Vertical">
+                                                <Label Name="DocAuthorLabelValue" Text="{Loc 'sv-document-console-author-label-value-none'}" ClipText="True"/>
+                                                <Label Name="DocLastEditedByLabelValue" Text="{Loc 'sv-document-console-editedby-label-value-none'}" ClipText="True"/>
+                                                <Label Name="DocDateLabelValue" Text="{Loc 'sv-document-console-date-label-value-none'}" ClipText="True"/>
+                                            </BoxContainer>
                                         </BoxContainer>
                                     </BoxContainer>
-                                </BoxContainer>
-                            </PanelContainer>
+                                </PanelContainer>
+                                <!-- Security record card. Unlike the details card above it, this describes the
+                                     selected crew member rather than the open document, and every value comes
+                                     live from station records. Security consoles only. -->
+                                <PanelContainer Name="SecurityRecordPanel" StyleClasses="BorderedWindowPanel" HorizontalExpand="True" Margin="0 5 0 0" Visible="False">
+                                    <BoxContainer Orientation="Vertical" Margin="6 4 6 4">
+                                        <Label Text="{Loc 'sv-document-console-security-heading'}" StyleClasses="LabelKeyText" Margin="0 0 0 4"/>
+                                        <BoxContainer>
+                                            <BoxContainer HorizontalAlignment="Left" Orientation="Vertical" Margin="0 0 8 0">
+                                                <Label Text="{Loc 'sv-document-console-security-status-label'}"/>
+                                                <Label Text="{Loc 'sv-document-console-security-reason-label'}"/>
+                                                <Label Text="{Loc 'sv-document-console-fingerprint-label'}"/>
+                                            </BoxContainer>
+                                            <BoxContainer HorizontalExpand="True" Orientation="Vertical">
+                                                <Label Name="DocSecurityStatusLabelValue" Text="-" ClipText="True"/>
+                                                <Label Name="DocSecurityReasonLabelValue" Text="-" ClipText="True"/>
+                                                <Label Name="DocFingerprintLabelValue" Text="-" ClipText="True"/>
+                                            </BoxContainer>
+                                        </BoxContainer>
+                                    </BoxContainer>
+                                </PanelContainer>
+                            </BoxContainer>
                             <!-- Right Control panel: actions in a bordered card. -->
                             <PanelContainer StyleClasses="BorderedWindowPanel" HorizontalExpand="True" VerticalExpand="True" Margin="5 0 0 0">
                                 <BoxContainer Orientation="Vertical" Margin="6 4 6 4">

--- a/Content.Client/_SV/CharacterDocuments/UI/CharacterDocumentConsoleWindow.xaml.cs
+++ b/Content.Client/_SV/CharacterDocuments/UI/CharacterDocumentConsoleWindow.xaml.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Sector-Vestige contributors
+// SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+// SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Client.RichText;
 using Content.Shared._SV.CharacterDocuments;
 using Content.Shared._SV.CharacterDocuments.Consoles;

--- a/Content.Client/_SV/CharacterDocuments/UI/CharacterDocumentConsoleWindow.xaml.cs
+++ b/Content.Client/_SV/CharacterDocuments/UI/CharacterDocumentConsoleWindow.xaml.cs
@@ -309,20 +309,20 @@ public sealed partial class CharacterDocumentConsoleWindow : DefaultWindow
         var hasPlayer = state.SelectedPlayer.HasValue;
         StatusButton.Visible = isSecurity;
         StatusButton.Disabled = !hasPlayer;
-        DocSecurityStatusLabel.Visible = isSecurity;
-        DocSecurityStatusLabelValue.Visible = isSecurity;
-        DocSecurityReasonLabel.Visible = isSecurity;
-        DocSecurityReasonLabelValue.Visible = isSecurity;
+        SecurityRecordPanel.Visible = isSecurity;
 
         if (isSecurity && hasPlayer)
         {
             DocSecurityStatusLabelValue.Text = state.SecurityStatus.ToString();
             DocSecurityReasonLabelValue.Text = state.SecurityReason ?? Loc.GetString("sv-document-console-security-na");
+            // Null when this crew member has no station record, or their record never captured a print.
+            DocFingerprintLabelValue.Text = state.SelectedPlayerFingerprint ?? Loc.GetString("sv-document-console-security-na");
         }
         else
         {
             DocSecurityStatusLabelValue.Text = Loc.GetString("sv-document-console-security-none");
             DocSecurityReasonLabelValue.Text = Loc.GetString("sv-document-console-security-na");
+            DocFingerprintLabelValue.Text = Loc.GetString("sv-document-console-security-na");
         }
 
         foreach (var (uid, name) in state.PlayerList.OrderBy(x => x.Value))

--- a/Content.IntegrationTests/Tests/_SV/CharacterDocuments/CharacterDocumentConsoleFingerprintTest.cs
+++ b/Content.IntegrationTests/Tests/_SV/CharacterDocuments/CharacterDocumentConsoleFingerprintTest.cs
@@ -1,0 +1,88 @@
+#nullable enable
+using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
+using Content.Server._SV.CharacterDocuments.Consoles;
+using Content.Server.StationRecords.Systems;
+using Content.Shared.StationRecords;
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests._SV.CharacterDocuments;
+
+/// <summary>
+///     The security documents console shows a crew member's fingerprint, which it has to fetch from
+///     that station's records. Documents are keyed by ProfileId but station records are keyed by an
+///     opaque uint, so the only link between them is the character's name — that match is the part
+///     that breaks, and it is what these tests cover.
+/// </summary>
+public sealed class CharacterDocumentConsoleFingerprintTest : GameTest
+{
+    private const string CrewName = "Alice Kane";
+    private const string CrewFingerprint = "VXK92MC01LL8T";
+
+    [SidedDependency(Side.Server)]
+    private readonly CharacterDocumentConsoleSystem _docConsole = null!;
+
+    [SidedDependency(Side.Server)]
+    private readonly StationRecordsSystem _stationRecords = null!;
+
+    public override PoolSettings PoolSettings => new()
+    {
+        Connected = false
+    };
+
+    /// <summary>
+    ///     Builds a records holder carrying one general record for <see cref="CrewName"/>.
+    /// </summary>
+    private Entity<StationRecordsComponent> MakeStationWithRecord(string name, string? fingerprint)
+    {
+        var station = SEntMan.Spawn();
+        var records = SEntMan.AddComponent<StationRecordsComponent>(station);
+
+        _stationRecords.AddRecordEntry(station,
+            new GeneralStationRecord { Name = name, Fingerprint = fingerprint },
+            records);
+
+        return (station, records);
+    }
+
+    [Test]
+    public async Task FingerprintIsFoundByCharacterName()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var station = MakeStationWithRecord(CrewName, CrewFingerprint);
+
+            Assert.That(_docConsole.TryGetRecordKeyByName(station, CrewName, out var key), Is.True,
+                "The console could not match a crew member to their own station record.");
+            Assert.That(_stationRecords.TryGetRecord<GeneralStationRecord>(key, out var record, station.Comp), Is.True);
+            Assert.That(record!.Fingerprint, Is.EqualTo(CrewFingerprint));
+        });
+    }
+
+    [Test]
+    public async Task UnknownCharacterNameResolvesNothing()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var station = MakeStationWithRecord(CrewName, CrewFingerprint);
+
+            Assert.That(_docConsole.TryGetRecordKeyByName(station, "Nobody Here", out _), Is.False,
+                "A name with no station record resolved to a key anyway.");
+        });
+    }
+
+    [Test]
+    public async Task RecordWithoutFingerprintResolvesNull()
+    {
+        // Records made before a fingerprint was available keep a null, which the console renders as N/A.
+        await Server.WaitAssertion(() =>
+        {
+            var station = MakeStationWithRecord(CrewName, null);
+
+            Assert.That(_docConsole.TryGetRecordKeyByName(station, CrewName, out var key), Is.True);
+            Assert.That(_stationRecords.TryGetRecord<GeneralStationRecord>(key, out var record, station.Comp), Is.True);
+            Assert.That(record!.Fingerprint, Is.Null);
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/_SV/CharacterDocuments/CharacterDocumentConsoleFingerprintTest.cs
+++ b/Content.IntegrationTests/Tests/_SV/CharacterDocuments/CharacterDocumentConsoleFingerprintTest.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Wizards Den contributors
+// SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+// SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+//
+// SPDX-License-Identifier: MIT
+
 #nullable enable
 using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Fixtures.Attributes;

--- a/Content.Server/_SV/CharacterDocuments/Consoles/CharacterDocumentConsoleSystem.cs
+++ b/Content.Server/_SV/CharacterDocuments/Consoles/CharacterDocumentConsoleSystem.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Sector-Vestige contributors
+// SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+// SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Diagnostics.CodeAnalysis;
 using Content.Server.Administration.Logs;
 using Content.Shared.Database;

--- a/Content.Server/_SV/CharacterDocuments/Consoles/CharacterDocumentConsoleSystem.cs
+++ b/Content.Server/_SV/CharacterDocuments/Consoles/CharacterDocumentConsoleSystem.cs
@@ -157,11 +157,11 @@ public sealed partial class CharacterDocumentConsoleSystem : EntitySystem
                     : null;
             }
 
-            var (secStatus, secReason) = comp.DocumentType == DocumentType.Security
-                ? GetCriminalStatus(uid, record)
-                : (SecurityStatus.None, null);
+            var (secStatus, secReason, secFingerprint) = comp.DocumentType == DocumentType.Security
+                ? GetSecurityInfo(uid, record)
+                : (SecurityStatus.None, null, null);
 
-            var state = new CharacterDocumentConsoleState(netPlayerEntities, comp.SelectedPlayer, filteredDocs, comp.SelectedDocument, paperinserted, comp.DocumentType, secStatus, secReason, additionalDocumentTypes: comp.AdditionalDocumentTypes, selectedPlayerGeneral: record.General);
+            var state = new CharacterDocumentConsoleState(netPlayerEntities, comp.SelectedPlayer, filteredDocs, comp.SelectedDocument, paperinserted, comp.DocumentType, secStatus, secReason, additionalDocumentTypes: comp.AdditionalDocumentTypes, selectedPlayerGeneral: record.General, selectedPlayerFingerprint: secFingerprint);
             PushState(uid, state);
         }
         else
@@ -203,11 +203,11 @@ public sealed partial class CharacterDocumentConsoleSystem : EntitySystem
         comp.SelectedPlayer = args.ProfileId;
         bool paperinserted = comp.PaperSlot.ContainerSlot?.ContainedEntity != null;
 
-        var (secStatus, secReason) = comp.DocumentType == DocumentType.Security
-            ? GetCriminalStatus(uid, record)
-            : (SecurityStatus.None, null);
+        var (secStatus, secReason, secFingerprint) = comp.DocumentType == DocumentType.Security
+            ? GetSecurityInfo(uid, record)
+            : (SecurityStatus.None, null, null);
 
-        var characterDocumentConsoleState = new CharacterDocumentConsoleState(netPlayerEntities, args.ProfileId, filteredDocs, null, paperinserted, comp.DocumentType, secStatus, secReason, additionalDocumentTypes: comp.AdditionalDocumentTypes, selectedPlayerGeneral: record.General);
+        var characterDocumentConsoleState = new CharacterDocumentConsoleState(netPlayerEntities, args.ProfileId, filteredDocs, null, paperinserted, comp.DocumentType, secStatus, secReason, additionalDocumentTypes: comp.AdditionalDocumentTypes, selectedPlayerGeneral: record.General, selectedPlayerFingerprint: secFingerprint);
         PushState(uid, characterDocumentConsoleState);
     }
 
@@ -231,11 +231,11 @@ public sealed partial class CharacterDocumentConsoleSystem : EntitySystem
 
         bool paperinserted = comp.PaperSlot.ContainerSlot?.ContainedEntity != null;
 
-        var (secStatus, secReason) = comp.DocumentType == DocumentType.Security
-            ? GetCriminalStatus(uid, record)
-            : (SecurityStatus.None, null);
+        var (secStatus, secReason, secFingerprint) = comp.DocumentType == DocumentType.Security
+            ? GetSecurityInfo(uid, record)
+            : (SecurityStatus.None, null, null);
 
-        var characterDocumentConsoleState = new CharacterDocumentConsoleState(netPlayerEntities, args.ProfileId, filteredDocs, selecteddoc, paperinserted, comp.DocumentType, secStatus, secReason, additionalDocumentTypes: comp.AdditionalDocumentTypes, selectedPlayerGeneral: record.General);
+        var characterDocumentConsoleState = new CharacterDocumentConsoleState(netPlayerEntities, args.ProfileId, filteredDocs, selecteddoc, paperinserted, comp.DocumentType, secStatus, secReason, additionalDocumentTypes: comp.AdditionalDocumentTypes, selectedPlayerGeneral: record.General, selectedPlayerFingerprint: secFingerprint);
         PushState(uid, characterDocumentConsoleState);
     }
 
@@ -548,12 +548,9 @@ public sealed partial class CharacterDocumentConsoleSystem : EntitySystem
         if (!TryGetListedRecord(listing, args.ProfileId, out var record))
             return;
 
-        var recordListing = _stationRecords.BuildListing((station.Value, stationRecords), null);
-        var recordKey = recordListing.FirstOrDefault(x => x.Value == record.Name);
-        if (recordKey.Value == null)
+        if (!TryGetRecordKeyByName((station.Value, stationRecords), record.Name, out var key))
             return;
 
-        var key = new StationRecordKey(recordKey.Key, station.Value);
         if (!_criminalRecords.TryChangeStatus(key, args.Status, args.Reason, null))
             return;
 
@@ -576,31 +573,50 @@ public sealed partial class CharacterDocumentConsoleSystem : EntitySystem
 
         var filteredDocs = BuildVisibleDocs(uid, comp, record);
 
-        var (newStatus, newReason) = GetCriminalStatus(uid, record);
+        var (newStatus, newReason, newFingerprint) = GetSecurityInfo(uid, record);
         bool paperInserted = comp.PaperSlot.ContainerSlot?.ContainedEntity != null;
-        var refreshState = new CharacterDocumentConsoleState(netPlayerEntities, args.ProfileId, filteredDocs, comp.SelectedDocument, paperInserted, comp.DocumentType, newStatus, newReason, additionalDocumentTypes: comp.AdditionalDocumentTypes, selectedPlayerGeneral: record.General);
+        var refreshState = new CharacterDocumentConsoleState(netPlayerEntities, args.ProfileId, filteredDocs, comp.SelectedDocument, paperInserted, comp.DocumentType, newStatus, newReason, additionalDocumentTypes: comp.AdditionalDocumentTypes, selectedPlayerGeneral: record.General, selectedPlayerFingerprint: newFingerprint);
         PushState(uid, refreshState);
     }
 
-    private (SecurityStatus status, string? reason) GetCriminalStatus(EntityUid consoleUid, CharacterDocumentRecord record)
+    /// <summary>
+    ///     Resolves a crew member's station-record key from their character name. Documents are keyed
+    ///     by ProfileId and station records by an opaque uint, so the name is the only link between
+    ///     the two.
+    /// </summary>
+    public bool TryGetRecordKeyByName(Entity<StationRecordsComponent> station, string characterName, out StationRecordKey key)
+    {
+        key = StationRecordKey.Invalid;
+
+        var listing = _stationRecords.BuildListing((station.Owner, station.Comp), null);
+        var match = listing.FirstOrDefault(x => x.Value == characterName);
+        if (match.Value == null)
+            return false;
+
+        key = new StationRecordKey(match.Key, station.Owner);
+        return true;
+    }
+
+    private (SecurityStatus status, string? reason, string? fingerprint) GetSecurityInfo(EntityUid consoleUid, CharacterDocumentRecord record)
     {
         var station = _stationSystem.GetOwningStation(consoleUid);
         if (station == null)
-            return (SecurityStatus.None, null);
+            return (SecurityStatus.None, null, null);
 
         if (!TryComp<StationRecordsComponent>(station, out var stationRecords))
-            return (SecurityStatus.None, null);
+            return (SecurityStatus.None, null, null);
 
-        var listing = _stationRecords.BuildListing((station.Value, stationRecords), null);
-        var recordKey = listing.FirstOrDefault(x => x.Value == record.Name);
-        if (recordKey.Value == null)
-            return (SecurityStatus.None, null);
+        if (!TryGetRecordKeyByName((station.Value, stationRecords), record.Name, out var key))
+            return (SecurityStatus.None, null, null);
 
-        var key = new StationRecordKey(recordKey.Key, station.Value);
+        var fingerprint = _stationRecords.TryGetRecord<GeneralStationRecord>(key, out var generalRecord, stationRecords)
+            ? generalRecord.Fingerprint
+            : null;
+
         if (!_stationRecords.TryGetRecord<CriminalRecord>(key, out var criminalRecord, stationRecords))
-            return (SecurityStatus.None, null);
+            return (SecurityStatus.None, null, fingerprint);
 
-        return (criminalRecord.Status, criminalRecord.Reason);
+        return (criminalRecord.Status, criminalRecord.Reason, fingerprint);
     }
 
     /// <summary>

--- a/Content.Shared/_SV/CharacterDocuments/Consoles/CharacterDocumentConsoleState.cs
+++ b/Content.Shared/_SV/CharacterDocuments/Consoles/CharacterDocumentConsoleState.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Sector-Vestige contributors
+// SPDX-FileCopyrightText: 2026 Sector Vestige contributors (modifications)
+// SPDX-FileCopyrightText: 2026 ReboundQ3 <22770594+ReboundQ3@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared._SV.CharacterDocuments.Components;
 using Content.Shared.Security;
 using Robust.Shared.Serialization;

--- a/Content.Shared/_SV/CharacterDocuments/Consoles/CharacterDocumentConsoleState.cs
+++ b/Content.Shared/_SV/CharacterDocuments/Consoles/CharacterDocumentConsoleState.cs
@@ -23,6 +23,12 @@ public sealed class CharacterDocumentConsoleState : BoundUserInterfaceState
     public SecurityStatus SecurityStatus;
     public string? SecurityReason;
     /// <summary>
+    /// Selected player's fingerprint, read from their station record. Null when no player is
+    /// selected, no station record matches their name, or the record never captured one.
+    /// Security consoles only; other document types leave this null.
+    /// </summary>
+    public string? SelectedPlayerFingerprint;
+    /// <summary>
     /// Selected player's General flavour block (allergies, height, etc). Null if no player selected.
     /// Console UIs render relevant fields based on the active tab (or primary type for single-type consoles).
     /// </summary>
@@ -41,7 +47,8 @@ public sealed class CharacterDocumentConsoleState : BoundUserInterfaceState
         DocumentType documentType = DocumentType.Employment,
         SecurityStatus securityStatus = SecurityStatus.None, string? securityReason = null,
         List<DocumentType>? additionalDocumentTypes = null,
-        CharacterDocumentGeneral? selectedPlayerGeneral = null)
+        CharacterDocumentGeneral? selectedPlayerGeneral = null,
+        string? selectedPlayerFingerprint = null)
     {
         PlayerList = playerlist;
         SelectedPlayer = selectedplayer;
@@ -53,5 +60,6 @@ public sealed class CharacterDocumentConsoleState : BoundUserInterfaceState
         SecurityReason = securityReason;
         AdditionalDocumentTypes = additionalDocumentTypes ?? new List<DocumentType>();
         SelectedPlayerGeneral = selectedPlayerGeneral;
+        SelectedPlayerFingerprint = selectedPlayerFingerprint;
     }
 }

--- a/Resources/Locale/en-US/_SV/characterdocuments/console.ftl
+++ b/Resources/Locale/en-US/_SV/characterdocuments/console.ftl
@@ -82,8 +82,10 @@ sv-document-lobby-edit-popup-content-too-long = Content too long: {$current} / {
 sv-document-lobby-preview-empty = (no document selected)
 sv-document-lobby-preview-author-default = (your character)
 
+sv-document-console-security-heading = Security Record
 sv-document-console-security-status-label = Status:
 sv-document-console-security-reason-label = Reason:
+sv-document-console-fingerprint-label = Fingerprint:
 sv-document-console-security-none = None
 sv-document-console-security-na = N/A
 


### PR DESCRIPTION
<!-- New to Sector Vestige? Please read our CONTRIBUTING guide:
https://github.com/Sector-Vestige/Sector-Vestige/blob/master/CONTRIBUTING.md -->

## About the PR
<!--
What does this PR do?
Briefly summarize the changes, features, or fixes introduced.
-->

IT brings back the fingerprint field to the security computer

## Why / Balance
<!--
Why was this change made?
- Does it fix a bug or issue? Link to the issue if applicable.
- Does it add a new feature? Explain the motivation.
- Does it affect game balance, gameplay design, or user experience? Explain how.
- Performance improvements? Describe the impact.
-->

@TheNarwhalrus reported to me that Gila said that the fingerprint field was missing, after a quick look it indeed was.

<img width="210" height="153" alt="image" src="https://github.com/user-attachments/assets/8b49bb2b-c5ad-411a-9a0e-92cdf2527c42" />

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Open dev -> open sec console -> notice the fingerprint field is back

## Media
<!--
Include screenshots or videos if this PR adds or changes anything visual.
If this PR is purely backend code or doesn't require visual demonstration, you can leave this section empty.
-->

<img width="587" height="229" alt="image" src="https://github.com/user-attachments/assets/73f9492b-f7b5-413a-8c94-9609363cb03a" />


## Technical Details
<!--
Explain any significant code-level details or logic.
Mention refactors, edge cases, or anything maintainers should be aware of.
If this is a simple change, you can keep this brief or omit it.
-->

  - CharacterDocumentConsoleSystem.cs - new public TryGetRecordKeyByName, and GetCriminalStatus became GetSecurityInfo returning the fingerprint alongside status and reason
  - CharacterDocumentConsoleState.cs - SelectedPlayerFingerprint, optional ctor param defaulting to null
  - CharacterDocumentConsoleWindow.xaml / .xaml.cs - the two labels and their visibility logic
  - console.ftl - sv-document-console-fingerprint-label
  - New Tests/_SV/CharacterDocuments/CharacterDocumentConsoleFingerprintTest.cs

## Breaking Changes
<!--
List any breaking changes to code structure or content.
This includes prototype name changes, class renames, or field changes that could affect downstream forks.
If there are none, write: "None"
-->

None

## Requirements
<!-- Confirm the following by placing an X inside each [ ] -->
- [X] I have tested all added content and code changes.
- [X] I have added media to this PR if it includes visual changes, or it does not require visual demonstration.
- [X] I understand that by submitting this PR, my code contributions are licensed under the AGPL-3.0-or-later used by Sector Vestige (only if under _SV namespace, files in other namespaces retain their licence ).

<!-- PRs that do not meet these requirements may be delayed or closed. -->

## Changelog
<!--
List player-facing changes below using this exact format.
Only entries after the ':cl:' tag will be picked up by Weh Bot.

Valid types: add, remove, tweak, fix
Use lowercase only (e.g., 'add', not 'Add').

Example:
:cl:
- add: Added new medical scanner UI.
- fix: Fixed lockers not opening.
-->

:cl:
- fix: Security console shows fingerprints again.
